### PR TITLE
Add riddles.io to competitive programming

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ When learning CS there are some useful sites you must know to get always informe
   * [Google Code Jam Practice and ](https://code.google.com/codejam/contests.html) : past contest problems for practice
   * [Sphere Online Judge (SPOJ) ](http://www.spoj.com/)
   * [Art of Problem Solving](https://artofproblemsolving.com/)
+  * [Riddles.io AI Games](https://www.riddles.io)
 # Computer Books
   * [IT eBooks - Free Download - Big Library  ](http://it-ebooks.info/): website for downloading ebooks without any advertisement and instant downloads.
   * [github.com/vhf/free-programming-books ](https://github.com/vhf/free-programming-books/blob/master/free-programming-books.md) : More than 500 free ebooks on almost any language you can think of

--- a/README.md
+++ b/README.md
@@ -304,7 +304,8 @@ When learning CS there are some useful sites you must know to get always informe
   * [Google Code Jam Practice and ](https://code.google.com/codejam/contests.html) : past contest problems for practice
   * [Sphere Online Judge (SPOJ) ](http://www.spoj.com/)
   * [Art of Problem Solving](https://artofproblemsolving.com/)
-  * [Riddles.io AI Games](https://www.riddles.io)
+  * [Riddles.io AI Games](https://www.riddles.io) : Compete with your bot and dominate the leaderboards!
+
   
 # Computer Books
   * [IT eBooks - Free Download - Big Library  ](http://it-ebooks.info/) : website for downloading ebooks without any advertisement and instant downloads.

--- a/README.md
+++ b/README.md
@@ -306,7 +306,6 @@ When learning CS there are some useful sites you must know to get always informe
   * [Art of Problem Solving](https://artofproblemsolving.com/)
   * [Riddles.io AI Games](https://www.riddles.io) : Compete with your bot and dominate the leaderboards!
 
-  
 # Computer Books
   * [IT eBooks - Free Download - Big Library  ](http://it-ebooks.info/) : website for downloading ebooks without any advertisement and instant downloads.
   * [github.com/vhf/free-programming-books ](https://github.com/vhf/free-programming-books/blob/master/free-programming-books.md) : More than 500 free ebooks on almost any language you can think of


### PR DESCRIPTION
The competition was formerly hosted at http://theaigames.com/ but has since migrated over to riddles.io.