### PR TITLE
Replace Google C++ Style Guidelines with C++ Core

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ When learning CS there are some useful sites you must know to get always informe
 
 # Coding Style
    * [CS 106B Coding Style Guide](http://stanford.edu/class/archive/cs/cs106b/cs106b.1158/styleguide.shtml): must see for those who create spaghetti
-   * [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html)
+   * [C++ Core Guidelines](https://github.com/isocpp/CppCoreGuidelines)
    * [What are some bad coding habits you would recommend a beginner avoid getting into?](https://www.reddit.com/r/learnprogramming/comments/1i4ds4/what_are_some_bad_coding_habits_you_would/)
    * [Good C programming habits. • /r/C_Programming](https://www.reddit.com/r/C_Programming/comments/1vuubw/good_c_programming_habits/)
    * [How to Report Bugs Effectively](http://www.chiark.greenend.org.uk/~sgtatham/bugs.html)


### PR DESCRIPTION
The C++ Core Guidelines were written to help people use modern C++. Google's guidelines are mainly focused on projects internal to Google. The C++ Core Guidelines are derived from the C++ community. Google's guidelines are derived from within Google.