### PR TITLE
NOKIA Wroclaw Technology Center -> code::dive conference

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ When learning CS there are some useful sites you must know to get always informe
   * [yegor256 ](https://www.youtube.com/user/technoparkcorp/videos)
   * [Scott Meyers: Past Talks ](http://www.aristeia.com/presentations.html)
   * [thoughtbot  ](https://www.youtube.com/user/ThoughtbotVideo/videos) : talks on various topics
-  * [NOKIA Wroclaw Technology Center ](https://www.youtube.com/channel/UC_l25lelCgcHtn3TeSyAQQA/videos): Nokia code dive conference
+  * [code::dive conference](https://www.youtube.com/channel/UCU0Rt8VHO5-YNQXwIjkf-1g) : code::dive conference organized by NOKIA Wrocław Technology Center
   * [HowToBecomeTV ](https://www.youtube.com/user/HowToBecomeTV/videos) : contains good interviews of developers and people related to tech industry.
   * [ITCuties ](https://www.youtube.com/user/itcuties/videos).
   * [CodeBabes](https://www.youtube.com/user/CodeBabes/videos) : For those who think CS lacks glamor :P


### PR DESCRIPTION
code::dive conference (organized by NOKIA Wrocław Technology Center) has its own YouTube channel. Old lectures (2014 and 2015) are on both channels (code::dive's one has them by playlists) while new ones (2016) are only on code::dive's channel and so will it be with upcoming 2017 edition.

Furthermore code::dive conference has its own [web page](http://codedive.pl/), [Facebook profile](https://www.facebook.com/CodeDiveWroclaw/) and [Twitter profile](https://twitter.com/code_dive_pl). However, for the purpose of this list they don't seem as useful as the [YouTube channel](https://www.youtube.com/channel/UCU0Rt8VHO5-YNQXwIjkf-1g) added here.

I am NOKIA Wrocław Technology Center's employee, co-organizer code::dive conference and a speaker there.