### PR TITLE
Feature/fix from bot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ before_script:
   - npm install --global awesome-lint
 script:
   - awesome-lint
-  - awesome_bot README.md
+  - awesome_bot README.md --white-list www.cubrid.org,medium.freecodecamp.com,learn.hackerearth.com,wildlyinaccurate.com,projecteuler.net,www.coursera.org,www.topcoder.com,www.codechef.com,www.joelonsoftware.com

--- a/README.md
+++ b/README.md
@@ -41,428 +41,428 @@ When learning CS there are some useful sites you must know to get always informe
 </ul>
 
 ## When you get stuck
-   * [Stack Overflow](http://stackoverflow.com/) : subscribe to their weekly newsletter and any other topic which you find interesting
-   * [Quora](https://www.quora.com/) : A place to share knowledge and better understand the world:
-   * [Learn Anything](https://learn-anything.xyz/) : Community curated knowledge graph of best paths for learning anything
+- [Stack Overflow](http://stackoverflow.com/) : subscribe to their weekly newsletter and any other topic which you find interesting
+- [Quora](https://www.quora.com/) : A place to share knowledge and better understand the world:
+- [Learn Anything](https://learn-anything.xyz/) : Community curated knowledge graph of best paths for learning anything
 
 ## News
-   * [Hacker News](https://news.ycombinator.com/) : news aggregator for programmers where civility is king, try a newsletter to get top news to your inbox:
-   * [Hacker Newsletter](http://www.hackernewsletter.com/) : curated by hand, delivered weekly
-   * [Hacker News Digest](https://hndigest.com/) : curated automatically, delivered as frequently as you want
-   * [Ars Technica](http://arstechnica.com/) : posts unique quality articles
-   * [ACM TechNews](http://technews.acm.org/)
-   * [Lobsters](https://lobste.rs/) : Lobsters is a technology-focused community centered around link aggregation and discussion.
-   * [TechCrunch](http://techcrunch.com/) : another good website for tech news
-   * [GSMArena.com](http://gsmarena.com/) : news related to latest mobile phones and android.
-   * [product hunt ](https://www.producthunt.com/) : Discover your next favorite thing
-   * [AlternativeTo](https://alternativeto.net) : Crowdsourced software recommendations
-   * [Better Dev Links](https://betterdev.link) : Weekly links to help you become a better developer
+- [Hacker News](https://news.ycombinator.com/) : news aggregator for programmers where civility is king, try a newsletter to get top news to your inbox:
+- [Hacker Newsletter](http://www.hackernewsletter.com/) : curated by hand, delivered weekly
+- [Hacker News Digest](https://hndigest.com/) : curated automatically, delivered as frequently as you want
+- [Ars Technica](http://arstechnica.com/) : posts unique quality articles
+- [ACM TechNews](http://technews.acm.org/)
+- [Lobsters](https://lobste.rs/) : Lobsters is a technology-focused community centered around link aggregation and discussion.
+- [TechCrunch](http://techcrunch.com/) : another good website for tech news
+- [GSMArena.com](http://gsmarena.com/) : news related to latest mobile phones and android.
+- [product hunt ](https://www.producthunt.com/) : Discover your next favorite thing
+- [AlternativeTo](https://alternativeto.net) : Crowdsourced software recommendations
+- [Better Dev Links](https://betterdev.link) : Weekly links to help you become a better developer
 
 ## Coding practice for beginners
-   * [freeCodeCamp](https://www.freecodecamp.com/) : Learn to code and build projects for nonprofits. Build your full stack web development portfolio today
-   * [Reddit.com/r/dailyprogrammer](http://www.reddit.com/r/dailyprogrammer) : interesting programming challenges where you can learn from looking at other's code , even if you are not able to solve code you can look at how others solved.
-   * [Programming by Doing](http://programmingbydoing.com/) : very good site for those who want to start with absolute basics
-   * [CodeAbbey - a place where everyone can master programming](http://codeabbey.com/) : Best place to begin with problems that start at the easiest and gradually increase difficulty with each problem.
-   * [Exercism.io](http://exercism.io/) : download and solve practice problems in over 30 different languages, and share your solution with others.
-   * [Programming Tasks](http://rosettacode.org/wiki/Category:Programming_Tasks) : large collection of small programs
-   * [karan/Projects-Solutions](https://github.com/karan/Projects-Solutions) Solutions to most of the problems in the link above
-   * [Lod - Cloud](http://lod-cloud.net/) : The Linking Open Data cloud diagram
-   * [Cave of programming](https://caveofprogramming.com/) : Learn to program, Upgrade your skills.
-   * [Codeacademy](https://www.codecademy.com/) : Learn to code interactively, for free.
+- [freeCodeCamp](https://www.freecodecamp.com/) : Learn to code and build projects for nonprofits. Build your full stack web development portfolio today
+- [Reddit.com/r/dailyprogrammer](http://www.reddit.com/r/dailyprogrammer) : interesting programming challenges where you can learn from looking at other's code , even if you are not able to solve code you can look at how others solved.
+- [Programming by Doing](http://programmingbydoing.com/) : very good site for those who want to start with absolute basics
+- [CodeAbbey - a place where everyone can master programming](http://codeabbey.com/) : Best place to begin with problems that start at the easiest and gradually increase difficulty with each problem.
+- [Exercism.io](http://exercism.io/) : download and solve practice problems in over 30 different languages, and share your solution with others.
+- [Programming Tasks](http://rosettacode.org/wiki/Category:Programming_Tasks) : large collection of small programs
+- [karan/Projects-Solutions](https://github.com/karan/Projects-Solutions) Solutions to most of the problems in the link above
+- [Lod - Cloud](http://lod-cloud.net/) : The Linking Open Data cloud diagram
+- [Cave of programming](https://caveofprogramming.com/) : Learn to program, Upgrade your skills.
+- [Codeacademy](https://www.codecademy.com/) : Learn to code interactively, for free.
 
 ## For those who want to start a small project but can't find the ideas
-   * [martyr2s-mega-project-ideas-list](http://www.dreamincode.net/forums/topic/78802-martyr2s-mega-project-ideas-list/) : contains about 125 project ideas from beginner to intermediate level.
-   * [karan/Projects](https://github.com/karan/Projects) : a large collection of small projects for beginners with
-   * [Wrong "big projects" for beginners](http://rodiongork.tumblr.com/post/108155476418/wrong-big-projects-for-beginners) : How to choose where to start
-   * [vicky002/1000-Projects](https://github.com/vicky002/1000_Projects) : Mega List of practical projects that one can solve in any programming language!
+- [martyr2s-mega-project-ideas-list](http://www.dreamincode.net/forums/topic/78802-martyr2s-mega-project-ideas-list/) : contains about 125 project ideas from beginner to intermediate level.
+- [karan/Projects](https://github.com/karan/Projects) : a large collection of small projects for beginners with
+- [Wrong "big projects" for beginners](http://rodiongork.tumblr.com/post/108155476418/wrong-big-projects-for-beginners) : How to choose where to start
+- [vicky002/1000-Projects](https://github.com/vicky002/1000_Projects) : Mega List of practical projects that one can solve in any programming language!
 
 ## General Coding advice
-   * [Things I Wish Someone Had Told Me When I Was Learning How to Code — Free Code Camp](https://medium.freecodecamp.com/things-i-wish-someone-had-told-me-when-i-was-learning-how-to-code-565fc9dcb329#.y5wbd3pj6)
-   * [Lessons From A Lifetime Of Being A Programmer](http://thecodist.com/article/lessons_from_a_lifetime_of_being_a_programmer)
-   * [Principles of Good Programming](http://www.artima.com/weblogs/viewpost.jsp?thread=331531)
-   * [What every computer science major should know](http://matt.might.net/articles/what-cs-majors-should-know/)
-   * [How to become a programmer, or the art of Googling well](https://okepi.wordpress.com/2014/08/21/how-to-become-a-programmer-or-the-art-of-googling-well/)
-   * [Code Review Best Practices](http://kevinlondon.com/2015/05/05/code-review-best-practices.html)
-   * [Dieter Rams : 10 Principles of Good Product Design](https://stephenhaunts.com/2013/12/11/dieter-rams-10-principles-of-good-product-design/)
-   * [10-ways-to-be-a-better-developer](https://stephenhaunts.files.wordpress.com/2014/04/10-ways-to-be-a-better-developer.png)
-   * [Working as a Software Developer](https://henrikwarne.com/2012/12/12/working-as-a-software-developer/)
-   * [Software design pattern](https://en.wikipedia.org/wiki/Software_design_pattern) : The entire collection of Design Patterns.
-   * [Design Patterns](https://sourcemaking.com/design_patterns) : Design Patterns explained in detail with examples.
+- [Things I Wish Someone Had Told Me When I Was Learning How to Code — Free Code Camp](https://medium.freecodecamp.com/things-i-wish-someone-had-told-me-when-i-was-learning-how-to-code-565fc9dcb329#.y5wbd3pj6)
+- [Lessons From A Lifetime Of Being A Programmer](http://thecodist.com/article/lessons_from_a_lifetime_of_being_a_programmer)
+- [Principles of Good Programming](http://www.artima.com/weblogs/viewpost.jsp?thread=331531)
+- [What every computer science major should know](http://matt.might.net/articles/what-cs-majors-should-know/)
+- [How to become a programmer, or the art of Googling well](https://okepi.wordpress.com/2014/08/21/how-to-become-a-programmer-or-the-art-of-googling-well/)
+- [Code Review Best Practices](http://kevinlondon.com/2015/05/05/code-review-best-practices.html)
+- [Dieter Rams : 10 Principles of Good Product Design](https://stephenhaunts.com/2013/12/11/dieter-rams-10-principles-of-good-product-design/)
+- [10-ways-to-be-a-better-developer](https://stephenhaunts.files.wordpress.com/2014/04/10-ways-to-be-a-better-developer.png)
+- [Working as a Software Developer](https://henrikwarne.com/2012/12/12/working-as-a-software-developer/)
+- [Software design pattern](https://en.wikipedia.org/wiki/Software_design_pattern) : The entire collection of Design Patterns.
+- [Design Patterns](https://sourcemaking.com/design_patterns) : Design Patterns explained in detail with examples.
 
 ## Coding Style
-   * [CS 106B Coding Style Guide](http://stanford.edu/class/archive/cs/cs106b/cs106b.1158/styleguide.shtml) : must see for those who create spaghetti
-   * [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html)
-   * [Airbnb JS Style Guide](https://github.com/airbnb/javascript) : A mostly reasonable approach to JavaScript
-   * [What are some bad coding habits you would recommend a beginner avoid getting into?](https://www.reddit.com/r/learnprogramming/comments/1i4ds4/what_are_some_bad_coding_habits_you_would/)
-   * [Good C programming habits. • /r/C_Programming](https://www.reddit.com/r/C_Programming/comments/1vuubw/good_c_programming_habits/)
-   * [How to Report Bugs Effectively](http://www.chiark.greenend.org.uk/~sgtatham/bugs.html)
-   * [Debugging Faqs](http://www.umich.edu/~eecs381/generalFAQ/Debugging.html)
-   * [Stuff you need to Code Better!](http://codebetter.com/)
-   * [Directory of Online CS Courses](https://github.com/open-source-society/computer-science)
-   * [Directory of CS Courses (many with online lectures)](https://github.com/prakhar1989/awesome-courses)
-   * [Angular 1 Style Guide](https://github.com/johnpapa/angular-styleguide/tree/master/a1) : Officially endorsed style guide by John Pappa
+- [CS 106B Coding Style Guide](http://stanford.edu/class/archive/cs/cs106b/cs106b.1158/styleguide.shtml) : must see for those who create spaghetti
+- [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html)
+- [Airbnb JS Style Guide](https://github.com/airbnb/javascript) : A mostly reasonable approach to JavaScript
+- [What are some bad coding habits you would recommend a beginner avoid getting into?](https://www.reddit.com/r/learnprogramming/comments/1i4ds4/what_are_some_bad_coding_habits_you_would/)
+- [Good C programming habits. • /r/C_Programming](https://www.reddit.com/r/C_Programming/comments/1vuubw/good_c_programming_habits/)
+- [How to Report Bugs Effectively](http://www.chiark.greenend.org.uk/~sgtatham/bugs.html)
+- [Debugging Faqs](http://www.umich.edu/~eecs381/generalFAQ/Debugging.html)
+- [Stuff you need to Code Better!](http://codebetter.com/)
+- [Directory of Online CS Courses](https://github.com/open-source-society/computer-science)
+- [Directory of CS Courses (many with online lectures)](https://github.com/prakhar1989/awesome-courses)
+- [Angular 1 Style Guide](https://github.com/johnpapa/angular-styleguide/tree/master/a1) : Officially endorsed style guide by John Pappa
    
 ## General Tools
 
 ### Interview Preparation
-  * [GeeksforGeeks | A computer science portal for geeks](http://www.geeksforgeeks.org/) : also subscribe to their feeds to get links to their new articles.
-  * [A site for technical interview questions, brain teasers, puzzles, quizzles](http://www.techinterview.org/) : whatever the heck those are) and other things that make you think!
-  * [Problems | LeetCode OJ ](https://leetcode.com/problemset/algorithms/) : Coding practice for interviews
-  * [Programmer And Software Interview Questions Answers](http://www.programmerinterview.com/)
-  * [Reddit.com/user/ashish2199/m/puzzles](https://www.reddit.com/user/ashish2199/m/puzzles) : Logic Puzzles
-  * [A Collection of Quant Riddles With Answers](http://puzzles.nigelcoldwell.co.uk/)
-  * [Aptitude Questions and Answers](http://www.indiabix.com/) : Quant and aptitude preparation
-  * [Interview Archives - Java Honk](http://javahonk.com/category/interview/)
-  * [Top 10 Algorithms for Coding Interview](http://www.programcreek.com/2012/11/top-10-algorithms-for-coding-interview/)
-  * [Algorithm design canvas](http://www.hiredintech.com/algorithm-design/))
-  * [Big-O Algorithm Complexity Cheat Sheet](http://bigocheatsheet.com/#)
-  * [Unix / Linux Cheat Sheet](http://cheatsheetworld.com/programming/unix-linux-cheat-sheet/)
-  * [How to interview](http://kelukelu.me/interview/index.html)
-  * [How to Ace an Algorithms Interview](http://www.palantir.com/2011/09/how-to-rock-an-algorithms-interview/)
-  * [Delightful Puzzles ](http://gurmeet.net/puzzles/)
-  * [visualising data structures and algorithms through animation](http://visualgo.net/)
-  * [Here's How to Prepare for Tech Interviews • /r/cscareerquestions](https://www.reddit.com/r/cscareerquestions/comments/1jov24/heres_how_to_prepare_for_tech_interviews/)
-  * [Guide to Tech Interviews](http://www.kchodorow.com/blog/2013/02/28/guide-to-tech-interviews/)
-  * [Why You Make Less Money • /r/cscareerquestions](https://www.reddit.com/r/cscareerquestions/comments/1b8wa3/why_you_make_less_money/)
-  * [IIT Delhi Placement Experience](http://placement-iit2013.blogspot.in/)
-  * [what_are_your_goto_questions_for_the_do_you_have?](https://www.reddit.com/r/cscareerquestions/comments/209rkq/what_are_your_goto_questions_for_the_do_you_have/)
-  * [/r/cscareerquestions](https://www.reddit.com/r/cscareerquestions/comments/20ahfq/heres_a_pretty_big_list_of_programming_interview/) : Here's a pretty big list of programming interview questions I compiled while studying for big 4 interviews. I think you guys will find it useful! •
-  * [Interviewing At Jane Street](https://blogs.janestreet.com/interviewing-at-jane-street/)
-  * [How to prepare for an interview - 1](http://se7so.blogspot.in/2014/01/how-to-prepare-for-interview-1.html)
-  * [Summer Internship: The Ultimate Guide](eulercoder.me/blog/career/Summer-Internship-the-ultimate-guide)
-  * [The 25 most difficult HR questions ](http://www.datsi.fi.upm.es/~frosal/docs/25mdq.html)
-  * [Job interviews News, Videos, Reviews and Gossip - Lifehacker ](http://lifehacker.com/tag/job-interviews)
-  * [How to Answer the Toughest 40 Job Interview Questions | ICS Job Portal ](http://www.icsjobportal.com/blog/job-interview-questions/)
-  * [Job Interview Questions and Best Answers ](http://jobsearch.about.com/od/interviewquestionsanswers/a/interviewquest.htm)
-  * [How to Answer "Tell Me a Little About Yourself" | The Art of Manliness ](http://www.artofmanliness.com/2016/01/05/tell-me-a-little-about-yourself/)
-  * [Job Interview: How to Ace a Job Interview | The Art of Manliness ](http://www.artofmanliness.com/2012/08/06/how-to-ace-a-job-interview/)
-  * [Give your résumé a face lift ](http://www.lifeclever.com/give-your-resume-a-face-lift/)
-  * [BIG O Misconceptions ](http://ssp.impulsetrain.com/big-o.html)
-  * [Bitwise tricks ](https://gist.github.com/dideler/2365607)
-  * [Core Java Interview questions - Interview question on each topic ](http://javahonk.com/core-java-interview-questions/)
-  * [Java Interview Questions and Answers ](http://adnjavainterview.blogspot.in)
-  * [Big collection of interview preparation links • /r/cscareerquestions ](https://www.reddit.com/r/cscareerquestions/comments/2lzc4h/big_collection_of_interview_preparation_links/)
-  * [Unsolicited_advice_for_job_seekers_and_employers ](https://www.reddit.com/r/india/comments/1clgdj/unsolicited_advice_for_job_seekers_and_employers/)
-  * [five-essential-phone-screen-questions - steveyegge2 ](https://sites.google.com/site/steveyegge2/five-essential-phone-screen-questions)
-  * [CS9: Problem-Solving for the CS Technical Interview ](http://web.stanford.edu/class/cs9/)
-  * [Mission-peace/interview problems ](https://github.com/mission-peace/interview/wiki) : A large collection of coding interview problems
-  * [SQL Joins explained using venn diagram ](http://stevestedman.com/wp-content/uploads/VennDiagram1.pdf)
-  * [10 Frequently asked SQL Query Interview Questions ](http://java67.blogspot.in/2013/04/10-frequently-asked-sql-query-interview-questions-answers-database.html)
-  * [Get Ready to Learn SQL: 8. Database Normalization Explained in Simple English - Essential SQL ](http://www.essentialsql.com/get-ready-to-learn-sql-database-normalization-explained-in-simple-english/)
-  * [Programming Language Concepts: Lecture Notes ](http://www.cmi.ac.in/~madhavan/courses/pl2006/lecturenotes/lecture-notes/lecture-notes.html) : OOPs concepts and programming language concepts.
-  * [We Help Coders Get Hired](http://www.hiredintech.com/app) : website offering courses on system design, interview strategies, soft skills etc
-  * [checkcheckzz/system-design-interview](https://github.com/checkcheckzz/system-design-interview)
-  * [How to Break Into the Tech Industry - a Guide to Job Hunting and Tech Interviews ](http://haseebq.com/how-to-break-into-tech-job-hunting-and-interviews/)
-  * [Freshers Interviews](http://placementsindia.blogspot.in/)
-  * [C PUZZLES, Some interesting C problems ](http://www.gowrikumar.com/c/index.php)
-  * [A site for technical interview questions, brain teasers, puzzles, quizzles (whatever the heck those are) and other things that make you think! ](http://www.techinterview.org/)
-  * [ wu :: riddles(hard) ](https://www.ocf.berkeley.edu/~wwu/riddles/hard.shtml) : logic puzzles and riddles
-  * [https://github.com/odino/interviews](https://github.com/odino/interviews) : list of important questions for interview
-  * [svozniuk/java-interviews](https://github.com/svozniuk/java-interviews) : Java interview questions
-  * [kimberli/interviews](https://github.com/kimberli/interviews) : study sheet for Interview
-  * [Determining the big-O runtimes of these different loops?](http://stackoverflow.com/questions/11094330/determining-the-big-o-runtimes-of-these-different-loops) : really good stackoverflow question that covers basics of calculating runtime complexity.
-  * [ChiperSoft/InterviewThis](https://github.com/ChiperSoft/InterviewThis) : questions to ask during on a interview to know more about the company.
-  * [SQL interview questions](https://www.jitbit.com/news/181-jitbits-sql-interview-questions/) : great SQL test
+- [GeeksforGeeks | A computer science portal for geeks](http://www.geeksforgeeks.org/) : also subscribe to their feeds to get links to their new articles.
+- [A site for technical interview questions, brain teasers, puzzles, quizzles](http://www.techinterview.org/) : whatever the heck those are) and other things that make you think!
+- [Problems | LeetCode OJ ](https://leetcode.com/problemset/algorithms/) : Coding practice for interviews
+- [Programmer And Software Interview Questions Answers](http://www.programmerinterview.com/)
+- [Reddit.com/user/ashish2199/m/puzzles](https://www.reddit.com/user/ashish2199/m/puzzles) : Logic Puzzles
+- [A Collection of Quant Riddles With Answers](http://puzzles.nigelcoldwell.co.uk/)
+- [Aptitude Questions and Answers](http://www.indiabix.com/) : Quant and aptitude preparation
+- [Interview Archives - Java Honk](http://javahonk.com/category/interview/)
+- [Top 10 Algorithms for Coding Interview](http://www.programcreek.com/2012/11/top-10-algorithms-for-coding-interview/)
+- [Algorithm design canvas](http://www.hiredintech.com/algorithm-design/))
+- [Big-O Algorithm Complexity Cheat Sheet](http://bigocheatsheet.com/#)
+- [Unix / Linux Cheat Sheet](http://cheatsheetworld.com/programming/unix-linux-cheat-sheet/)
+- [How to interview](http://kelukelu.me/interview/index.html)
+- [How to Ace an Algorithms Interview](http://www.palantir.com/2011/09/how-to-rock-an-algorithms-interview/)
+- [Delightful Puzzles ](http://gurmeet.net/puzzles/)
+- [visualising data structures and algorithms through animation](http://visualgo.net/)
+- [Here's How to Prepare for Tech Interviews • /r/cscareerquestions](https://www.reddit.com/r/cscareerquestions/comments/1jov24/heres_how_to_prepare_for_tech_interviews/)
+- [Guide to Tech Interviews](http://www.kchodorow.com/blog/2013/02/28/guide-to-tech-interviews/)
+- [Why You Make Less Money • /r/cscareerquestions](https://www.reddit.com/r/cscareerquestions/comments/1b8wa3/why_you_make_less_money/)
+- [IIT Delhi Placement Experience](http://placement-iit2013.blogspot.in/)
+- [what_are_your_goto_questions_for_the_do_you_have?](https://www.reddit.com/r/cscareerquestions/comments/209rkq/what_are_your_goto_questions_for_the_do_you_have/)
+- [/r/cscareerquestions](https://www.reddit.com/r/cscareerquestions/comments/20ahfq/heres_a_pretty_big_list_of_programming_interview/) : Here's a pretty big list of programming interview questions I compiled while studying for big 4 interviews. I think you guys will find it useful! •
+- [Interviewing At Jane Street](https://blogs.janestreet.com/interviewing-at-jane-street/)
+- [How to prepare for an interview - 1](http://se7so.blogspot.in/2014/01/how-to-prepare-for-interview-1.html)
+- [Summer Internship: The Ultimate Guide](eulercoder.me/blog/career/Summer-Internship-the-ultimate-guide)
+- [The 25 most difficult HR questions ](http://www.datsi.fi.upm.es/~frosal/docs/25mdq.html)
+- [Job interviews News, Videos, Reviews and Gossip - Lifehacker ](http://lifehacker.com/tag/job-interviews)
+- [How to Answer the Toughest 40 Job Interview Questions | ICS Job Portal ](http://www.icsjobportal.com/blog/job-interview-questions/)
+- [Job Interview Questions and Best Answers ](http://jobsearch.about.com/od/interviewquestionsanswers/a/interviewquest.htm)
+- [How to Answer "Tell Me a Little About Yourself" | The Art of Manliness ](http://www.artofmanliness.com/2016/01/05/tell-me-a-little-about-yourself/)
+- [Job Interview: How to Ace a Job Interview | The Art of Manliness ](http://www.artofmanliness.com/2012/08/06/how-to-ace-a-job-interview/)
+- [Give your résumé a face lift ](http://www.lifeclever.com/give-your-resume-a-face-lift/)
+- [BIG O Misconceptions ](http://ssp.impulsetrain.com/big-o.html)
+- [Bitwise tricks ](https://gist.github.com/dideler/2365607)
+- [Core Java Interview questions - Interview question on each topic ](http://javahonk.com/core-java-interview-questions/)
+- [Java Interview Questions and Answers ](http://adnjavainterview.blogspot.in)
+- [Big collection of interview preparation links • /r/cscareerquestions ](https://www.reddit.com/r/cscareerquestions/comments/2lzc4h/big_collection_of_interview_preparation_links/)
+- [Unsolicited_advice_for_job_seekers_and_employers ](https://www.reddit.com/r/india/comments/1clgdj/unsolicited_advice_for_job_seekers_and_employers/)
+- [five-essential-phone-screen-questions - steveyegge2 ](https://sites.google.com/site/steveyegge2/five-essential-phone-screen-questions)
+- [CS9: Problem-Solving for the CS Technical Interview ](http://web.stanford.edu/class/cs9/)
+- [Mission-peace/interview problems ](https://github.com/mission-peace/interview/wiki) : A large collection of coding interview problems
+- [SQL Joins explained using venn diagram ](http://stevestedman.com/wp-content/uploads/VennDiagram1.pdf)
+- [10 Frequently asked SQL Query Interview Questions ](http://java67.blogspot.in/2013/04/10-frequently-asked-sql-query-interview-questions-answers-database.html)
+- [Get Ready to Learn SQL: 8. Database Normalization Explained in Simple English - Essential SQL ](http://www.essentialsql.com/get-ready-to-learn-sql-database-normalization-explained-in-simple-english/)
+- [Programming Language Concepts: Lecture Notes ](http://www.cmi.ac.in/~madhavan/courses/pl2006/lecturenotes/lecture-notes/lecture-notes.html) : OOPs concepts and programming language concepts.
+- [We Help Coders Get Hired](http://www.hiredintech.com/app) : website offering courses on system design, interview strategies, soft skills etc
+- [checkcheckzz/system-design-interview](https://github.com/checkcheckzz/system-design-interview)
+- [How to Break Into the Tech Industry - a Guide to Job Hunting and Tech Interviews ](http://haseebq.com/how-to-break-into-tech-job-hunting-and-interviews/)
+- [Freshers Interviews](http://placementsindia.blogspot.in/)
+- [C PUZZLES, Some interesting C problems ](http://www.gowrikumar.com/c/index.php)
+- [A site for technical interview questions, brain teasers, puzzles, quizzles (whatever the heck those are) and other things that make you think! ](http://www.techinterview.org/)
+- [ wu :: riddles(hard) ](https://www.ocf.berkeley.edu/~wwu/riddles/hard.shtml) : logic puzzles and riddles
+- [https://github.com/odino/interviews](https://github.com/odino/interviews) : list of important questions for interview
+- [svozniuk/java-interviews](https://github.com/svozniuk/java-interviews) : Java interview questions
+- [kimberli/interviews](https://github.com/kimberli/interviews) : study sheet for Interview
+- [Determining the big-O runtimes of these different loops?](http://stackoverflow.com/questions/11094330/determining-the-big-o-runtimes-of-these-different-loops) : really good stackoverflow question that covers basics of calculating runtime complexity.
+- [ChiperSoft/InterviewThis](https://github.com/ChiperSoft/InterviewThis) : questions to ask during on a interview to know more about the company.
+- [SQL interview questions](https://www.jitbit.com/news/181-jitbits-sql-interview-questions/) : great SQL test
 
 ## Documentaries
-  * Machine that Changed the World - a very good documentary about history of computers
+- Machine that Changed the World - a very good documentary about history of computers
       * [Part 1: Giant Brains ](http://www.youtube.com/watch?v=rcR74y61xZk)
       * [Part 2: Inventing the Future](https://www.youtube.com/watch?v=0iPiYxjsYKk)
       * [Part 3: The Paperback Computer](https://www.youtube.com/watch?v=d7DKVfOXr54)
       * [Part 4: The Thinking Machine](https://www.youtube.com/watch?v=enWWlx7-t0k)
       * [Part 5: The World at Your Fingertips](https://www.youtube.com/watch?v=fLLXiP7diEo)
-  * [Triumph of the Nerds ](https://www.youtube.com/playlist?list=PLn-Y3vvQbmHO5WUcBdIWqiUfNawhC1cn3) : Play-list
-  * [Project Code Rush - The Beginnings of Netscape / Mozilla Documentary ](https://www.youtube.com/watch?v=a-49a_CjH0M)
-  * [The Code: Story of Linux documentary ](https://www.youtube.com/watch?v=XMm0HsmOTFI)
-  * [Breaking the Code: Biography of Alan Turing ](https://www.youtube.com/watch?v=S23yie-779k)
-  * [Mechanical Computer (All Parts) ](https://www.youtube.com/watch?v=s1i-dnAH9Y4) : a very good video from 1950s explaining how mechanical computers used to work without all the modern day electronics.
-  * [Download: The True Story of the Internet ](https://www.youtube.com/playlist?list=PL_IlIlrxhtPMqW4b0-v8OgLvFZQes6SoZ) : Play-list of discovery channel documentary on browser wars , dot com bubble and more.
-  * [Teach Yourself Computer Science ](https://teachyourselfcs.com/)
-  * [How does CPU execute program (video)](https://www.youtube.com/watch?v=42KTvGYQYnA)
-  * [Machine Code Instructions (video)](https://www.youtube.com/watch?v=Mv2XQgpbTNE)
-  * [Harvard CS50 - Asymptotic Notation (video)](https://www.youtube.com/watch?v=iOq5kSKqeR4)
-  * [Cracking The Code Interview](https://www.youtube.com/watch?v=4NIb9l3imAo)
-  * [Cracking the Coding Interview - Fullstack Speaker Series](https://www.youtube.com/watch?v=Eg5-tdAwclo)
-  * [Ask Me Anything: Gayle Laakmann McDowell (author of Cracking the Coding Interview)](https://www.youtube.com/watch?v=1fqxMuPmGak)
+- [Triumph of the Nerds ](https://www.youtube.com/playlist?list=PLn-Y3vvQbmHO5WUcBdIWqiUfNawhC1cn3) : Play-list
+- [Project Code Rush - The Beginnings of Netscape / Mozilla Documentary ](https://www.youtube.com/watch?v=a-49a_CjH0M)
+- [The Code: Story of Linux documentary ](https://www.youtube.com/watch?v=XMm0HsmOTFI)
+- [Breaking the Code: Biography of Alan Turing ](https://www.youtube.com/watch?v=S23yie-779k)
+- [Mechanical Computer (All Parts) ](https://www.youtube.com/watch?v=s1i-dnAH9Y4) : a very good video from 1950s explaining how mechanical computers used to work without all the modern day electronics.
+- [Download: The True Story of the Internet ](https://www.youtube.com/playlist?list=PL_IlIlrxhtPMqW4b0-v8OgLvFZQes6SoZ) : Play-list of discovery channel documentary on browser wars , dot com bubble and more.
+- [Teach Yourself Computer Science ](https://teachyourselfcs.com/)
+- [How does CPU execute program (video)](https://www.youtube.com/watch?v=42KTvGYQYnA)
+- [Machine Code Instructions (video)](https://www.youtube.com/watch?v=Mv2XQgpbTNE)
+- [Harvard CS50 - Asymptotic Notation (video)](https://www.youtube.com/watch?v=iOq5kSKqeR4)
+- [Cracking The Code Interview](https://www.youtube.com/watch?v=4NIb9l3imAo)
+- [Cracking the Coding Interview - Fullstack Speaker Series](https://www.youtube.com/watch?v=Eg5-tdAwclo)
+- [Ask Me Anything: Gayle Laakmann McDowell (author of Cracking the Coding Interview)](https://www.youtube.com/watch?v=1fqxMuPmGak)
 
 
 ## MOOCs for learning something new
-  * [Class Central](https://www.class-central.com) : a directory of 100,000+ student reviews of thousands of MOOCs.
-  * [NPTEL Vidoes COMP_SCI_ENGG ](https://onlinecourses.nptel.ac.in/explorer/search?category=COMP_SCI_ENGG)
-  * [Coursera.org](http://coursera.org/)
-  * [edX](http://edx.org/)
-  * [MOOC.fi](http://mooc.fi/english.html) : Free online courses from the University of Helsinki
-  * [Udacity](http://udacity.com/)
-  * [Kadenze | Creative Programming](https://www.kadenze.com/courses?subjects%5B%5D=7): Programming courses focused on art and creativity
-  * [UCBerkeley](https://www.youtube.com/user/UCBerkeley/videos)
-  * [MIT OCW Electrical Engineering and Computer Science](http://ocw.mit.edu/courses/electrical-engineering-and-computer-science/)
-  * [CS50](https://www.youtube.com/user/cs50tv/videos)
-  * [prakhar1989/awesome-CS-courses](https://github.com/prakhar1989/awesome-courses/blob/master/README.md) : List containing large amount of CS courses
-  * [Computer Science Resources ](https://docs.google.com/spreadsheets/d/1BD8BJJUNaX63m2QmySWMGDp71nx4W4MyyiIBlfMoN3Q/htmlview?sle=true#) : list of MOOCs for autodidacts
-  * [https://github.com/prakhar1989/awesome-courses/blob/master/README.md ](https://github.com/prakhar1989/awesome-courses/blob/master/README.md) : collection of CS courses on Internet
+- [Class Central](https://www.class-central.com) : a directory of 100,000+ student reviews of thousands of MOOCs.
+- [NPTEL Vidoes COMP_SCI_ENGG ](https://onlinecourses.nptel.ac.in/explorer/search?category=COMP_SCI_ENGG)
+- [Coursera.org](http://coursera.org/)
+- [edX](http://edx.org/)
+- [MOOC.fi](http://mooc.fi/english.html) : Free online courses from the University of Helsinki
+- [Udacity](http://udacity.com/)
+- [Kadenze | Creative Programming](https://www.kadenze.com/courses?subjects%5B%5D=7): Programming courses focused on art and creativity
+- [UCBerkeley](https://www.youtube.com/user/UCBerkeley/videos)
+- [MIT OCW Electrical Engineering and Computer Science](http://ocw.mit.edu/courses/electrical-engineering-and-computer-science/)
+- [CS50](https://www.youtube.com/user/cs50tv/videos)
+- [prakhar1989/awesome-CS-courses](https://github.com/prakhar1989/awesome-courses/blob/master/README.md) : List containing large amount of CS courses
+- [Computer Science Resources ](https://docs.google.com/spreadsheets/d/1BD8BJJUNaX63m2QmySWMGDp71nx4W4MyyiIBlfMoN3Q/htmlview?sle=true#) : list of MOOCs for autodidacts
+- [https://github.com/prakhar1989/awesome-courses/blob/master/README.md ](https://github.com/prakhar1989/awesome-courses/blob/master/README.md) : collection of CS courses on Internet
 
 ## Sites related to your preferred programming language (For me Java)
-  * [Java Revisited ](http://javarevisited.blogspot.in/) : good for learning about Java Language and interview preparation.
-  * [The Java™ Tutorials  ](https://docs.oracle.com/javase/tutorial/): The best tutorials for Java.
-  * [Java Corner at Artima.com ](http://www.artima.com/java/index.html)
-  * [Java Visualizer ](http://www.cs.princeton.edu/~cos126/java_visualize/) : helps visualize references , values of variables ect
-  * [Java Lecture Notes ](http://www.cafeaulait.org/course/)
-  * [Learning Java ](http://chimera.labs.oreilly.com/books/1234000001805/index.html) : a free online textbook for learning Java
-  * [Free Online Chapters of Inside the Java Virtual Machine by Bill Venners ](http://www.artima.com/insidejvm/ed2/index.html)
-  * [Understanding JVM Internals ](http://www.cubrid.org/blog/dev-platform/understanding-jvm-internals/)
-  * [How Garbage Collection Works ](http://www.dynatrace.com/en/javabook/how-garbage-collection-works.html)
-  * [Welcome to JavaWorld.com ](http://www.javaworld.com/)
-  * [The Java Memory Model ](http://www.cs.umd.edu/~pugh/java/memoryModel/)
-  * [Netbeans Keyboard Shortcuts ](https://netbeans.org/project_downloads/usersguide/shortcuts-80.pdf) : Keyboard shortcuts to enhance your productivity when working in Netbeans.
-  * [XyzWs Java FAQs ](http://www.xyzws.com/javafaq/page/1) : large collection of java interview questions
-  * [Search Open Source Java API ](http://www.docjar.com/) : view source of java library and learn how things are implemented.
-  * [JournalDev - Java, Java EE, Android, Web Development Tutorials](http://www.journaldev.com/)
-  * [Implementation of Algorithms and Data Structures, Interview Questions and Answers ](https://github.com/sherxon/AlgoDS)
-  * [what-is-garbage-collection](https://plumbr.eu/handbook/what-is-garbage-collection) : Demystify the garbage collection
-  * [Best books for learning java must read](https://javahungry.blogspot.com/2014/02/best-books-for-learning-java-must-read.html) : Get basics of Java
-  * [Garbage collection (Java); Augmenting data str (video)](https://www.youtube.com/watch?v=StdfeXaKGEc&list=PL-XXv-cvA_iAlnI-BQr9hjqADPBtujFJd&index=25)
-  * [Compilers (video)](https://www.youtube.com/playlist?list=PLO9y7hOkmmSGTy5z6HZ-W4k2y8WXF7Bff)
-  * [Deep Dive Java: Garbage Collection is Good!](https://www.infoq.com/presentations/garbage-collection-benefits)
-  * [The C++ Programming Language](http://www.stroustrup.com/C++.html) : The C++ Programming Language.
-  * [Bjarne Stroustrup's FAQ](http://www.stroustrup.com/bs_faq.html) : The C++ FAQ
-  * [Bjarne Stroustrup's C++ Style and Technique FAQ](http://www.stroustrup.com/bs_faq2.html) : The C++ FAQ
-  * [C++11 - the new ISO C++ standard](http://www.stroustrup.com/C++11FAQ.html) : The C++11 FAQ
+- [Java Revisited ](http://javarevisited.blogspot.in/) : good for learning about Java Language and interview preparation.
+- [The Java™ Tutorials  ](https://docs.oracle.com/javase/tutorial/): The best tutorials for Java.
+- [Java Corner at Artima.com ](http://www.artima.com/java/index.html)
+- [Java Visualizer ](http://www.cs.princeton.edu/~cos126/java_visualize/) : helps visualize references , values of variables ect
+- [Java Lecture Notes ](http://www.cafeaulait.org/course/)
+- [Learning Java ](http://chimera.labs.oreilly.com/books/1234000001805/index.html) : a free online textbook for learning Java
+- [Free Online Chapters of Inside the Java Virtual Machine by Bill Venners ](http://www.artima.com/insidejvm/ed2/index.html)
+- [Understanding JVM Internals ](http://www.cubrid.org/blog/dev-platform/understanding-jvm-internals/)
+- [How Garbage Collection Works ](http://www.dynatrace.com/en/javabook/how-garbage-collection-works.html)
+- [Welcome to JavaWorld.com ](http://www.javaworld.com/)
+- [The Java Memory Model ](http://www.cs.umd.edu/~pugh/java/memoryModel/)
+- [Netbeans Keyboard Shortcuts ](https://netbeans.org/project_downloads/usersguide/shortcuts-80.pdf) : Keyboard shortcuts to enhance your productivity when working in Netbeans.
+- [XyzWs Java FAQs ](http://www.xyzws.com/javafaq/page/1) : large collection of java interview questions
+- [Search Open Source Java API ](http://www.docjar.com/) : view source of java library and learn how things are implemented.
+- [JournalDev - Java, Java EE, Android, Web Development Tutorials](http://www.journaldev.com/)
+- [Implementation of Algorithms and Data Structures, Interview Questions and Answers ](https://github.com/sherxon/AlgoDS)
+- [what-is-garbage-collection](https://plumbr.eu/handbook/what-is-garbage-collection) : Demystify the garbage collection
+- [Best books for learning java must read](https://javahungry.blogspot.com/2014/02/best-books-for-learning-java-must-read.html) : Get basics of Java
+- [Garbage collection (Java); Augmenting data str (video)](https://www.youtube.com/watch?v=StdfeXaKGEc&list=PL-XXv-cvA_iAlnI-BQr9hjqADPBtujFJd&index=25)
+- [Compilers (video)](https://www.youtube.com/playlist?list=PLO9y7hOkmmSGTy5z6HZ-W4k2y8WXF7Bff)
+- [Deep Dive Java: Garbage Collection is Good!](https://www.infoq.com/presentations/garbage-collection-benefits)
+- [The C++ Programming Language](http://www.stroustrup.com/C++.html) : The C++ Programming Language.
+- [Bjarne Stroustrup's FAQ](http://www.stroustrup.com/bs_faq.html) : The C++ FAQ
+- [Bjarne Stroustrup's C++ Style and Technique FAQ](http://www.stroustrup.com/bs_faq2.html) : The C++ FAQ
+- [C++11 - the new ISO C++ standard](http://www.stroustrup.com/C++11FAQ.html) : The C++11 FAQ
 
 
 
 
 ## Learn AI
- * [Unsupervised Sentiment Neuron ](https://blog.openai.com/unsupervised-sentiment-neuron/)
- * [Robots that learn](https://blog.openai.com/robots-that-learn/)
- * [grakn.ai](https://grakn.ai/)
+- [Unsupervised Sentiment Neuron ](https://blog.openai.com/unsupervised-sentiment-neuron/)
+- [Robots that learn](https://blog.openai.com/robots-that-learn/)
+- [grakn.ai](https://grakn.ai/)
 
 ## Seminar , research writing , talks etc
-  * [Advice on Research and Writing ](http://www.cs.cmu.edu/~mleone/how-to.html)
-  * [Seminar and reports ](https://www.cse.iitb.ac.in/~ranade/communicationskills.html)
-  * [PHD MS Articles ](http://www.cse.iitd.ac.in/~srsarangi/articles.html)
-  * [Practical Tips for Talking at Usergroups and Conferences ](https://stephenhaunts.com/2015/10/02/practical-tips-for-talking-at-usergroups-and-conferences-part-1/)
-  * [ Giving presentation on software project to non-programmers ](https://stephenhaunts.com/2015/10/02/practical-tips-for-talking-at-usergroups-and-conferences-part-1/)
+- [Advice on Research and Writing ](http://www.cs.cmu.edu/~mleone/how-to.html)
+- [Seminar and reports ](https://www.cse.iitb.ac.in/~ranade/communicationskills.html)
+- [PHD MS Articles ](http://www.cse.iitd.ac.in/~srsarangi/articles.html)
+- [Practical Tips for Talking at Usergroups and Conferences ](https://stephenhaunts.com/2015/10/02/practical-tips-for-talking-at-usergroups-and-conferences-part-1/)
+- [ Giving presentation on software project to non-programmers ](https://stephenhaunts.com/2015/10/02/practical-tips-for-talking-at-usergroups-and-conferences-part-1/)
 
 ## Everything in one place
-  * [reddit.com/user/ashish2199/m/cs_student_subs](https://www.reddit.com/user/ashish2199/m/cs_student_subs) : a multisubreddit of all subreddits of topics related to computer science and programming.
+- [reddit.com/user/ashish2199/m/cs_student_subs](https://www.reddit.com/user/ashish2199/m/cs_student_subs) : a multisubreddit of all subreddits of topics related to computer science and programming.
 
 ## YouTube Channels
-  * [Computerphile ](https://www.youtube.com/user/Computerphile/videos) : Must watch for every CS student
-  * [ComputerHistory ](https://www.youtube.com/user/ComputerHistory/videos) : for those who like to know how we reached where we are.
-  * [GoogleTechTalks ](https://www.youtube.com/user/GoogleTechTalks/videos) : videos on trending topics and cool stuff happening in the tech industry.
-  * [Placement Grid ](https://www.youtube.com/user/PlacementGrid/videos) : Interview and campus placement experience
-  * [Google Developers ](https://www.youtube.com/user/GoogleDevelopers/videos)
-  * [Facebook Developers ](https://www.youtube.com/user/FacebookDevelopers/videos)
-  * [O'Reilly ](https://www.youtube.com/user/OreillyMedia/videos) : interviews and talks of world's best technical writers.
-  * [Java ](https://www.youtube.com/user/java/videos) : talks related to java
-  * [JavaOne ](https://www.youtube.com/channel/UCdDhYMT2USoLdh4SZIsu_1g/videos) : Java Conference
-  * [CppCon ](https://www.youtube.com/user/CppCon/videos?shelf_id=0&view=0&sort=dd) : C++ Conference
-  * [C++Now (BoostCon)](https://www.youtube.com/channel/UC5e__RG9K3cHrPotPABnrwg) : C++Now (previously BoostCon) conference
-  * [Meeting C++ YT Kanalseite ](https://www.youtube.com/user/MeetingCPP/videos) : Talks on C++
-  * [ThinMatrix ](https://www.youtube.com/user/ThinMatrix/videos) : blogs and tutorials developer making a 3d game in Java using opengl
-  * [yegor256 ](https://www.youtube.com/user/technoparkcorp/videos)
-  * [Scott Meyers: Past Talks ](http://www.aristeia.com/presentations.html)
-  * [thoughtbot  ](https://www.youtube.com/user/ThoughtbotVideo/videos) : talks on various topics
-  * [code::dive conference](https://www.youtube.com/channel/UCU0Rt8VHO5-YNQXwIjkf-1g) : code::dive conference organized by NOKIA Wrocław Technology Center
-  * [HowToBecomeTV ](https://www.youtube.com/user/HowToBecomeTV/videos) : contains good interviews of developers and people related to tech industry.
-  * [Siraj Raval](https://www.youtube.com/channel/UCWN3xxRkmTPmbKwht9FuE5A) : Artificial Intelligence and deep learning tutorials videos
-  * [Netflix UI Engineering](https://www.youtube.com/channel/UCGGRRqAjPm6sL3-WGBDnKJA/videos) : great videos to watch for web developers, mobile developers and those interested in some of Netflix's tech stack
-  * [Coding Blocks](https://www.youtube.com/CodingBlocks) : Tutorials, how to's, tips and tricks
-  * [Codely tv](https://www.youtube.com/UC9IKtxn9AIGelnYmwYr0Lxw) : Interviews, tips and tricks
-  * [Fun Fun Function](https://www.youtube.com/c/mpjmevideos) : A weekly series from Mattias Petter Johansson on an assortment of programming topics, including some not directly related to coding.
+- [Computerphile ](https://www.youtube.com/user/Computerphile/videos) : Must watch for every CS student
+- [ComputerHistory ](https://www.youtube.com/user/ComputerHistory/videos) : for those who like to know how we reached where we are.
+- [GoogleTechTalks ](https://www.youtube.com/user/GoogleTechTalks/videos) : videos on trending topics and cool stuff happening in the tech industry.
+- [Placement Grid ](https://www.youtube.com/user/PlacementGrid/videos) : Interview and campus placement experience
+- [Google Developers ](https://www.youtube.com/user/GoogleDevelopers/videos)
+- [Facebook Developers ](https://www.youtube.com/user/FacebookDevelopers/videos)
+- [O'Reilly ](https://www.youtube.com/user/OreillyMedia/videos) : interviews and talks of world's best technical writers.
+- [Java ](https://www.youtube.com/user/java/videos) : talks related to java
+- [JavaOne ](https://www.youtube.com/channel/UCdDhYMT2USoLdh4SZIsu_1g/videos) : Java Conference
+- [CppCon ](https://www.youtube.com/user/CppCon/videos?shelf_id=0&view=0&sort=dd) : C++ Conference
+- [C++Now (BoostCon)](https://www.youtube.com/channel/UC5e__RG9K3cHrPotPABnrwg) : C++Now (previously BoostCon) conference
+- [Meeting C++ YT Kanalseite ](https://www.youtube.com/user/MeetingCPP/videos) : Talks on C++
+- [ThinMatrix ](https://www.youtube.com/user/ThinMatrix/videos) : blogs and tutorials developer making a 3d game in Java using opengl
+- [yegor256 ](https://www.youtube.com/user/technoparkcorp/videos)
+- [Scott Meyers: Past Talks ](http://www.aristeia.com/presentations.html)
+- [thoughtbot  ](https://www.youtube.com/user/ThoughtbotVideo/videos) : talks on various topics
+- [code::dive conference](https://www.youtube.com/channel/UCU0Rt8VHO5-YNQXwIjkf-1g) : code::dive conference organized by NOKIA Wrocław Technology Center
+- [HowToBecomeTV ](https://www.youtube.com/user/HowToBecomeTV/videos) : contains good interviews of developers and people related to tech industry.
+- [Siraj Raval](https://www.youtube.com/channel/UCWN3xxRkmTPmbKwht9FuE5A) : Artificial Intelligence and deep learning tutorials videos
+- [Netflix UI Engineering](https://www.youtube.com/channel/UCGGRRqAjPm6sL3-WGBDnKJA/videos) : great videos to watch for web developers, mobile developers and those interested in some of Netflix's tech stack
+- [Coding Blocks](https://www.youtube.com/CodingBlocks) : Tutorials, how to's, tips and tricks
+- [Codely tv](https://www.youtube.com/UC9IKtxn9AIGelnYmwYr0Lxw) : Interviews, tips and tricks
+- [Fun Fun Function](https://www.youtube.com/c/mpjmevideos) : A weekly series from Mattias Petter Johansson on an assortment of programming topics, including some not directly related to coding.
 
 ## Good Articles
-  * [Expectations of a Junior Developer ](http://blog.thefirehoseproject.com/posts/expectations-of-a-junior-developer/)
-  * [The Key To Accelerating Your Coding Skills ](http://blog.thefirehoseproject.com/posts/learn-to-code-and-be-self-reliant/)
-  * [A Software Developer’s Reading List ](https://stevewedig.com/2014/02/03/software-developers-reading-list/) : Some good books and links in there.
-  * [how-to-break-into-tech-job-hunting-and-interviews/ ](http://haseebq.com/how-to-break-into-tech-job-hunting-and-interviews/)
-  * [40 Keys Computer Science Concepts Explained In Layman’s Terms ](http://carlcheo.com/compsci)
-  * [What every programmer should know about memory, Part 1](https://lwn.net/Articles/250967/)
-  * [We are reinventing the retail industry through innovative technology](http://multithreaded.stitchfix.com/)
-  * [Unicode ](https://www.joelonsoftware.com/2003/10/08/the-absolute-minimum-every-software-developer-absolutely-positively-must-know-about-unicode-and-character-sets-no-excuses/)
-  * [What every programmer absolutely, positively needs to know about encodings and character sets to work with text](http://kunststube.net/encoding/)
-  * [List of algorithms](https://www.wikiwand.com/en/List_of_algorithms)
-  * [Dive into the byte code](https://www.wikiwand.com/en/Java_bytecode)
-  * [What every computer science major should know ](http://matt.might.net/articles/what-cs-majors-should-know/)
-  * [Teach Yourself Computer Science](https://teachyourselfcs.com/)
-  * [Data Structure Map](https://fkcd.ca/b7d.svg)
-  * [A Gentle Introduction To Graph Theory ](https://dev.to/vaidehijoshi/a-gentle-introduction-to-graph-theory)
-  * [Linux Inside](https://0xax.gitbooks.io/linux-insides/content/Booting/linux-bootstrap-1.html)
-  * [A programmer friendly language that compiles to Lua.](http://moonscript.org/)
+- [Expectations of a Junior Developer ](http://blog.thefirehoseproject.com/posts/expectations-of-a-junior-developer/)
+- [The Key To Accelerating Your Coding Skills ](http://blog.thefirehoseproject.com/posts/learn-to-code-and-be-self-reliant/)
+- [A Software Developer’s Reading List ](https://stevewedig.com/2014/02/03/software-developers-reading-list/) : Some good books and links in there.
+- [how-to-break-into-tech-job-hunting-and-interviews/ ](http://haseebq.com/how-to-break-into-tech-job-hunting-and-interviews/)
+- [40 Keys Computer Science Concepts Explained In Layman’s Terms ](http://carlcheo.com/compsci)
+- [What every programmer should know about memory, Part 1](https://lwn.net/Articles/250967/)
+- [We are reinventing the retail industry through innovative technology](http://multithreaded.stitchfix.com/)
+- [Unicode ](https://www.joelonsoftware.com/2003/10/08/the-absolute-minimum-every-software-developer-absolutely-positively-must-know-about-unicode-and-character-sets-no-excuses/)
+- [What every programmer absolutely, positively needs to know about encodings and character sets to work with text](http://kunststube.net/encoding/)
+- [List of algorithms](https://www.wikiwand.com/en/List_of_algorithms)
+- [Dive into the byte code](https://www.wikiwand.com/en/Java_bytecode)
+- [What every computer science major should know ](http://matt.might.net/articles/what-cs-majors-should-know/)
+- [Teach Yourself Computer Science](https://teachyourselfcs.com/)
+- [Data Structure Map](https://fkcd.ca/b7d.svg)
+- [A Gentle Introduction To Graph Theory ](https://dev.to/vaidehijoshi/a-gentle-introduction-to-graph-theory)
+- [Linux Inside](https://0xax.gitbooks.io/linux-insides/content/Booting/linux-bootstrap-1.html)
+- [A programmer friendly language that compiles to Lua.](http://moonscript.org/)
 
 ## Podcasts
- * [Coding Blocks - Learning principles, patterns and better practices on the go](http://www.codingblocks.net/)
- * [MS Dev Show](http://msdevshow.com/)
- * [The Cynical Developer](http://cynicaldeveloper.com/)
- * [Herding Code](http://herdingcode.com/)
- * [Code Newbie](http://www.codenewbie.org/)
- * [Software Engineering Radio](http://www.se-radio.net/)
- * [JavaScript Jabber](https://devchat.tv/js-jabber)
- * [Developer Tea](https://spec.fm/podcasts/developer-tea) : A podcast for developers designed to fit inside your tea break.
- * [Full Stack Radio](http://www.fullstackradio.com/) : Everything from product design and user experience to unit testing and system administration. 
- * [Software Engineering Daily](https://softwareengineeringdaily.com/) : A daily technical interview about software topics
+- [Coding Blocks - Learning principles, patterns and better practices on the go](http://www.codingblocks.net/)
+- [MS Dev Show](http://msdevshow.com/)
+- [The Cynical Developer](http://cynicaldeveloper.com/)
+- [Herding Code](http://herdingcode.com/)
+- [Code Newbie](http://www.codenewbie.org/)
+- [Software Engineering Radio](http://www.se-radio.net/)
+- [JavaScript Jabber](https://devchat.tv/js-jabber)
+- [Developer Tea](https://spec.fm/podcasts/developer-tea) : A podcast for developers designed to fit inside your tea break.
+- [Full Stack Radio](http://www.fullstackradio.com/) : Everything from product design and user experience to unit testing and system administration. 
+- [Software Engineering Daily](https://softwareengineeringdaily.com/) : A daily technical interview about software topics
 
 ## Building a Simple Compiler/interpreter
- * [Resources for Amateur Compiler Writers](http://c9x.me/compile/bib/)
- * [:snowman: Possibly the smallest compiler ever](https://github.com/thejameskyle/the-super-tiny-compiler)
- * [Writing My First Compiler ](https://dev.to/fcpauldiaz/writing-my-first-compiler)
- * [Structure and Interpretation of Computer Programs](https://sarabander.github.io/sicp/html/index.xhtml)
- *  [Let’s Build A Simple Interpreter. Part 1. ](https://ruslanspivak.com/lsbasi-part1/)
- *  [Growing a compiler](http://www.cs.dartmouth.edu/~mckeeman/cs48/mxcom/gem/html/GrowingCompiler.html)
+- [Resources for Amateur Compiler Writers](http://c9x.me/compile/bib/)
+- [:snowman: Possibly the smallest compiler ever](https://github.com/thejameskyle/the-super-tiny-compiler)
+- [Writing My First Compiler ](https://dev.to/fcpauldiaz/writing-my-first-compiler)
+- [Structure and Interpretation of Computer Programs](https://sarabander.github.io/sicp/html/index.xhtml)
+-  [Let’s Build A Simple Interpreter. Part 1. ](https://ruslanspivak.com/lsbasi-part1/)
+-  [Growing a compiler](http://www.cs.dartmouth.edu/~mckeeman/cs48/mxcom/gem/html/GrowingCompiler.html)
 
 ## Tutorials
-  * [Subtle | Poor Man's CI](https://www.subtle.press/course/poor-mans-ci/) : Learn how continuous integration platforms work under the hood, by building one of your own on top of git with Node.js
-  * [Tutorialspoint ](http://www.tutorialspoint.com/)
-  * [W3Schools Online Web Tutorials ](http://www.w3schools.com/)
-  * [Open Data Structures ](http://opendatastructures.org/) : Excellent resource for learning about DS and algos , provides code in various languages C++ , Java , pseudocode
-  * [Data Structures and Algorithms by John Morris ](http://oopweb.com/Algorithms/Documents/PLDS210/VolumeFrames.html) : another good source with code and its analysis
-  * [CMSI 281: Data Structures ](http://cs.lmu.edu/~ray/classes/dsa/) : light weight introduction to DS
-  * [How to Program in C++  ](http://cs.fit.edu/~mmahoney/cse2050/how2cpp.html) : Good resource for revising C++ topics and STL
-  * [TopCoder Tutorials ](https://www.topcoder.com/community/data-science/data-science-tutorials/)
-  * [A Hacker's Guide to Git ](http://wildlyinaccurate.com/a-hackers-guide-to-git/) : for those wanting to learn git with a solid foundation
-  * [Git from the inside out ](http://maryrosecook.com/blog/post/git-from-the-inside-out)
-  * [Learn UNIX in 10 minutes](http://freeengineer.org/learnUNIXin10minutes.html)
-  * [The Bash Guide](http://guide.bash.academy/) : very good guide for learning the Bash Shell
-  * [Linux Tutorial ](http://ryanstutorials.net/linuxtutorial/) : good resource for learning Linux
-  * [UNIX Tutorial - Introduction ](http://www.ee.surrey.ac.uk/Teaching/Unix/unixintro.html)
-  * [Linux Tutorial for Beginners ](http://www.ee.surrey.ac.uk/Teaching/Unix/)
-  * [Learning the shell. ](http://linuxcommand.org/learning_the_shell.php)
-  * [Dynamic programming - PrismoSkills](http://prismoskills.appspot.com/lessons/Dynamic_Programming/Chapter_01_-_Introduction.jsp) : very good resource if want to learn how to solve DP problems.
-  * [Deep C  ](http://www.slideshare.net/olvemaudal/deep-c) : very good presentation on C language
-  * [C programming language Frequently Asked Questions ](http://c-faq.com/index.html)
-  * [OS Course Notes ](https://www.cs.uic.edu/~jbell/CourseNotes/OperatingSystems/) : Chapter wise course notes according to Galvin's book
-  * [SQL (Structured Query Language) in one page : SQL.SU ](http://www.cheat-sheets.org/sites/sql.su/) : a very good SQL cheat sheet
-  * [Introduction to C Programming ](http://www.le.ac.uk/users/rjm1/cotter/index.htm)
-  * [MySQL Essentials ](http://www.techotopia.com/index.php/MySQL_Essentials)
-  * [http://www.mysqltutorial.org/ ](http://www.mysqltutorial.org/)
-  * [Best Of - Gustavo Duarte  ](http://duartes.org/gustavo/blog/best-of/) : contains articles on various topics
-  * [Collecting all the cheat sheets ](http://overapi.com/) : cheat sheets for lots of programming languages
-  * [The Descent to C  ](http://www.chiark.greenend.org.uk/~sgtatham/cdescent/) : for those moving to C from some higher programming language like java or python.
-  * [VimTutor+ ](https://vimtutorplus.herokuapp.com/exercise/1) : learn VIM from browser itself
-  * [HackerEarth Tutorials ](https://learn.hackerearth.com/tutorials/) : Good resource for DS and Algos tutorial
-  * [Linux Journey ](https://linuxjourney.com/) : good site for learning linux
-  * [C Programming ](http://www.cs.cf.ac.uk/Dave/C/CE.html)
-  * [CS 2112/ENGRD 2112 Fall 2015 ](http://www.cs.cornell.edu/courses/cs2112/2015fa/lectures/index.html) : Good notes on data structures and algorithms.
-  * [More about Github-flavored markdown](https://guides.github.com/features/mastering-markdown/)
-  * [The Unix Programming Environment](http://product.half.ebay.com/The-UNIX-Programming-Environment-by-Brian-W-Kernighan-and-Rob-Pike-1983-Other/54385&tg=info)
-  * [The Linux Command Line: A Complete Introduction](https://www.amazon.com/dp/1593273894/)
-  * [TCP/IP Illustrated Series](https://en.wikipedia.org/wiki/TCP/IP_Illustrated)
-  * [Head First Design Patterns](https://www.amazon.com/gp/product/0596007124/)
-  * [Design Patterns: Elements of Reusable Object-Oriented Software](https://www.amazon.com/Design-Patterns-Elements-Reusable-Object-Oriented/dp/0201633612) : aka the "Gang Of Four" book, or GOF
-  * [UNIX and Linux System Administration Handbook, 4th Edition](https://www.amazon.com/UNIX-Linux-System-Administration-Handbook/dp/0131480057/)
-  * [Programming, Web Development, and DevOps news, tutorials and tools for beginners to experts](https://dzone.com/)
+- [Subtle | Poor Man's CI](https://www.subtle.press/course/poor-mans-ci/) : Learn how continuous integration platforms work under the hood, by building one of your own on top of git with Node.js
+- [Tutorialspoint ](http://www.tutorialspoint.com/)
+- [W3Schools Online Web Tutorials ](http://www.w3schools.com/)
+- [Open Data Structures ](http://opendatastructures.org/) : Excellent resource for learning about DS and algos , provides code in various languages C++ , Java , pseudocode
+- [Data Structures and Algorithms by John Morris ](http://oopweb.com/Algorithms/Documents/PLDS210/VolumeFrames.html) : another good source with code and its analysis
+- [CMSI 281: Data Structures ](http://cs.lmu.edu/~ray/classes/dsa/) : light weight introduction to DS
+- [How to Program in C++  ](http://cs.fit.edu/~mmahoney/cse2050/how2cpp.html) : Good resource for revising C++ topics and STL
+- [TopCoder Tutorials ](https://www.topcoder.com/community/data-science/data-science-tutorials/)
+- [A Hacker's Guide to Git ](http://wildlyinaccurate.com/a-hackers-guide-to-git/) : for those wanting to learn git with a solid foundation
+- [Git from the inside out ](http://maryrosecook.com/blog/post/git-from-the-inside-out)
+- [Learn UNIX in 10 minutes](http://freeengineer.org/learnUNIXin10minutes.html)
+- [The Bash Guide](http://guide.bash.academy/) : very good guide for learning the Bash Shell
+- [Linux Tutorial ](http://ryanstutorials.net/linuxtutorial/) : good resource for learning Linux
+- [UNIX Tutorial - Introduction ](http://www.ee.surrey.ac.uk/Teaching/Unix/unixintro.html)
+- [Linux Tutorial for Beginners ](http://www.ee.surrey.ac.uk/Teaching/Unix/)
+- [Learning the shell. ](http://linuxcommand.org/learning_the_shell.php)
+- [Dynamic programming - PrismoSkills](http://prismoskills.appspot.com/lessons/Dynamic_Programming/Chapter_01_-_Introduction.jsp) : very good resource if want to learn how to solve DP problems.
+- [Deep C  ](http://www.slideshare.net/olvemaudal/deep-c) : very good presentation on C language
+- [C programming language Frequently Asked Questions ](http://c-faq.com/index.html)
+- [OS Course Notes ](https://www.cs.uic.edu/~jbell/CourseNotes/OperatingSystems/) : Chapter wise course notes according to Galvin's book
+- [SQL (Structured Query Language) in one page : SQL.SU ](http://www.cheat-sheets.org/sites/sql.su/) : a very good SQL cheat sheet
+- [Introduction to C Programming ](http://www.le.ac.uk/users/rjm1/cotter/index.htm)
+- [MySQL Essentials ](http://www.techotopia.com/index.php/MySQL_Essentials)
+- [http://www.mysqltutorial.org/ ](http://www.mysqltutorial.org/)
+- [Best Of - Gustavo Duarte  ](http://duartes.org/gustavo/blog/best-of/) : contains articles on various topics
+- [Collecting all the cheat sheets ](http://overapi.com/) : cheat sheets for lots of programming languages
+- [The Descent to C  ](http://www.chiark.greenend.org.uk/~sgtatham/cdescent/) : for those moving to C from some higher programming language like java or python.
+- [VimTutor+ ](https://vimtutorplus.herokuapp.com/exercise/1) : learn VIM from browser itself
+- [HackerEarth Tutorials ](https://learn.hackerearth.com/tutorials/) : Good resource for DS and Algos tutorial
+- [Linux Journey ](https://linuxjourney.com/) : good site for learning linux
+- [C Programming ](http://www.cs.cf.ac.uk/Dave/C/CE.html)
+- [CS 2112/ENGRD 2112 Fall 2015 ](http://www.cs.cornell.edu/courses/cs2112/2015fa/lectures/index.html) : Good notes on data structures and algorithms.
+- [More about Github-flavored markdown](https://guides.github.com/features/mastering-markdown/)
+- [The Unix Programming Environment](http://product.half.ebay.com/The-UNIX-Programming-Environment-by-Brian-W-Kernighan-and-Rob-Pike-1983-Other/54385&tg=info)
+- [The Linux Command Line: A Complete Introduction](https://www.amazon.com/dp/1593273894/)
+- [TCP/IP Illustrated Series](https://en.wikipedia.org/wiki/TCP/IP_Illustrated)
+- [Head First Design Patterns](https://www.amazon.com/gp/product/0596007124/)
+- [Design Patterns: Elements of Reusable Object-Oriented Software](https://www.amazon.com/Design-Patterns-Elements-Reusable-Object-Oriented/dp/0201633612) : aka the "Gang Of Four" book, or GOF
+- [UNIX and Linux System Administration Handbook, 4th Edition](https://www.amazon.com/UNIX-Linux-System-Administration-Handbook/dp/0131480057/)
+- [Programming, Web Development, and DevOps news, tutorials and tools for beginners to experts](https://dzone.com/)
 
 
 ## Watch others code
-  * [LiveEdu.tv](https://www.liveedu.tv/) : screencast of people building application, websites, games, ect.
+- [LiveEdu.tv](https://www.liveedu.tv/) : screencast of people building application, websites, games, ect.
 
 ## What should a programmer know
-  * [Programmer Competency Matrix  ](http://sijinjoseph.com/programmer-competency-matrix/) : article for knowing what our level as a programmer is.
-  * [GitHub.com Build software better, together  ](https://github.com/) : Place to showcase your project and collaborate with others. (Must know Git in order to use it effectively)
-  * [Gitlab offers free unlimited (private) repositories and unlimited collaborators](https://gitlab.com).
+- [Programmer Competency Matrix  ](http://sijinjoseph.com/programmer-competency-matrix/) : article for knowing what our level as a programmer is.
+- [GitHub.com Build software better, together  ](https://github.com/) : Place to showcase your project and collaborate with others. (Must know Git in order to use it effectively)
+- [Gitlab offers free unlimited (private) repositories and unlimited collaborators](https://gitlab.com).
 
 ## Competitive programming
-  * [WakaTime](https://wakatime.com/) : leaderboards of coding metrics collected via editor plugins
-  * [HackerRank ](http://hackerrank.com/)
-  * [Codeforces ](http://codeforces.com/)
-  * [topcoder ](http://topcoder.com/)
-  * [UVa Online Judge ](https://uva.onlinejudge.org) : hundreds of problems supporting multiple languages.
-  * [HackerEarth - Programming challenges and Developer jobs ](http://hackerearth.com/)
-  * [CodeChef ](http://codechef.com/)
-  * [PKU ACM ICPC Practice problems ](http://poj.org/problemlist)
-  * [Archived Problems - Project Euler ](https://projecteuler.net/archives)
-  * [Google Code Jam Practice and ](https://code.google.com/codejam/contests.html) : past contest problems for practice
-  * [Sphere Online Judge (SPOJ) ](http://www.spoj.com/)
-  * [Art of Problem Solving](https://artofproblemsolving.com/)
-  * [Riddles.io AI Games](https://www.riddles.io) : Compete with your bot and dominate the leaderboards!
-  * [Codingame](https://www.codingame.com) : Learn coding through games and challenges!
-  * [Codewars](https://www.codewars.com/) : Rank up by completing code kata
-  * [Codefights](https://codefights.com/) : Test your coding skills
+- [WakaTime](https://wakatime.com/) : leaderboards of coding metrics collected via editor plugins
+- [HackerRank ](http://hackerrank.com/)
+- [Codeforces ](http://codeforces.com/)
+- [topcoder ](http://topcoder.com/)
+- [UVa Online Judge ](https://uva.onlinejudge.org) : hundreds of problems supporting multiple languages.
+- [HackerEarth - Programming challenges and Developer jobs ](http://hackerearth.com/)
+- [CodeChef ](http://codechef.com/)
+- [PKU ACM ICPC Practice problems ](http://poj.org/problemlist)
+- [Archived Problems - Project Euler ](https://projecteuler.net/archives)
+- [Google Code Jam Practice and ](https://code.google.com/codejam/contests.html) : past contest problems for practice
+- [Sphere Online Judge (SPOJ) ](http://www.spoj.com/)
+- [Art of Problem Solving](https://artofproblemsolving.com/)
+- [Riddles.io AI Games](https://www.riddles.io) : Compete with your bot and dominate the leaderboards!
+- [Codingame](https://www.codingame.com) : Learn coding through games and challenges!
+- [Codewars](https://www.codewars.com/) : Rank up by completing code kata
+- [Codefights](https://codefights.com/) : Test your coding skills
 
 ## Computer Books
-  * [IT eBooks - Free Download - Big Library  ](http://it-ebooks.info/) : website for downloading ebooks without any advertisement and instant downloads.
-  * [github.com/vhf/free-programming-books ](https://github.com/vhf/free-programming-books/blob/master/free-programming-books.md) : More than 500 free ebooks on almost any language you can think of
-  * [Computer Science Books Online ](http://www.sciencebooksonline.info/computer-science.html) : about 150 computer free ebooks
-  * [Best books for GATE CSE ](http://gatecse.in/wiki/Best_books_for_CSE#Best_Books_for_GATE_in_CSE)
-  * [https://cses.fi/book.html](https://cses.fi/book.html)
-  * [Library Genesis](http://gen.lib.rus.ec) : Almost any ebook you can think of, including countless CS texts and manuals.
+- [IT eBooks - Free Download - Big Library  ](http://it-ebooks.info/) : website for downloading ebooks without any advertisement and instant downloads.
+- [github.com/vhf/free-programming-books ](https://github.com/vhf/free-programming-books/blob/master/free-programming-books.md) : More than 500 free ebooks on almost any language you can think of
+- [Computer Science Books Online ](http://www.sciencebooksonline.info/computer-science.html) : about 150 computer free ebooks
+- [Best books for GATE CSE ](http://gatecse.in/wiki/Best_books_for_CSE#Best_Books_for_GATE_in_CSE)
+- [https://cses.fi/book.html](https://cses.fi/book.html)
+- [Library Genesis](http://gen.lib.rus.ec) : Almost any ebook you can think of, including countless CS texts and manuals.
 
 ## Video Tutorials
-  * [Tushar Roy ](https://www.youtube.com/user/tusharroy2525/videos) : Algorithm and Data structure tutorial by an Indian Youtuber.
-  * [Derek Banas ](https://www.youtube.com/user/derekbanas/videos) : good quality tutorials
-  * [thenewboston ](https://www.youtube.com/user/thenewboston/videos) : good but with too much talk as compared to actual content
-  * [mycodeschool ](https://www.youtube.com/user/mycodeschool/videos) : Data structures and algorithms tutorials
-  * [CodeGeek ](https://www.youtube.com/channel/UCJYhP1lceSUc1bg0LRBUvqA/videos)
-  * [CodingMadeEasy  ](https://www.youtube.com/user/CodingMadeEasy/videos) : C++ tutorials
-  * [XDA-University - Helping You Learn Android Development ](http://xda-university.com/)
-  * [DevTips ](https://www.youtube.com/user/DevTipsForDesigners/videos) : web dev tutorials
-  * [codedamn  ](https://www.youtube.com/channel/UCJUmE61LxhbhudzUugHL2wQ/videos) : front end web dev tutorials
-  * [Design and Analysis of Algorithms ](http://openclassroom.stanford.edu/MainFolder/CoursePage.php?course=IntroToAlgorithms)
-  * [Vim Tutorial Videos - Flarfnoogins ](http://derekwyatt.org/vim/tutorials/index.html) : good video tutorial for learning vim
-  * [CS1: Higher Computing - Richard Buckland UNSW ](https://www.youtube.com/playlist?list=PL6B940F08B9773B9F) : a very good introductory CS course
-  * [Kathryn Hodge ](https://www.youtube.com/channel/UC4DwZ2VXM2KWtzHjVk9M_xg/videos) : Has good videos for beginners
+- [Tushar Roy ](https://www.youtube.com/user/tusharroy2525/videos) : Algorithm and Data structure tutorial by an Indian Youtuber.
+- [Derek Banas ](https://www.youtube.com/user/derekbanas/videos) : good quality tutorials
+- [thenewboston ](https://www.youtube.com/user/thenewboston/videos) : good but with too much talk as compared to actual content
+- [mycodeschool ](https://www.youtube.com/user/mycodeschool/videos) : Data structures and algorithms tutorials
+- [CodeGeek ](https://www.youtube.com/channel/UCJYhP1lceSUc1bg0LRBUvqA/videos)
+- [CodingMadeEasy  ](https://www.youtube.com/user/CodingMadeEasy/videos) : C++ tutorials
+- [XDA-University - Helping You Learn Android Development ](http://xda-university.com/)
+- [DevTips ](https://www.youtube.com/user/DevTipsForDesigners/videos) : web dev tutorials
+- [codedamn  ](https://www.youtube.com/channel/UCJUmE61LxhbhudzUugHL2wQ/videos) : front end web dev tutorials
+- [Design and Analysis of Algorithms ](http://openclassroom.stanford.edu/MainFolder/CoursePage.php?course=IntroToAlgorithms)
+- [Vim Tutorial Videos - Flarfnoogins ](http://derekwyatt.org/vim/tutorials/index.html) : good video tutorial for learning vim
+- [CS1: Higher Computing - Richard Buckland UNSW ](https://www.youtube.com/playlist?list=PL6B940F08B9773B9F) : a very good introductory CS course
+- [Kathryn Hodge ](https://www.youtube.com/channel/UC4DwZ2VXM2KWtzHjVk9M_xg/videos) : Has good videos for beginners
 
 ## Online Compiler and Sharing Code snippets
-  * [CodePad](https://codepad.remoteinterview.io/) : Code editor to try, test and run 25+ languages
-  * [JSFiddle](https://jsfiddle.net/) : Test your JavaScript, CSS, HTML or CoffeeScript with online code editor
-  * [Ideone.com ](https://ideone.com/)
-  * [Pastebin.com ](http://pastebin.com/)
-  * [Godbolt.org ](https://godbolt.org/): Excellent tool for exploring the assembly output of different compilers with and without optimization.
+- [CodePad](https://codepad.remoteinterview.io/) : Code editor to try, test and run 25+ languages
+- [JSFiddle](https://jsfiddle.net/) : Test your JavaScript, CSS, HTML or CoffeeScript with online code editor
+- [Ideone.com ](https://ideone.com/)
+- [Pastebin.com ](http://pastebin.com/)
+- [Godbolt.org ](https://godbolt.org/): Excellent tool for exploring the assembly output of different compilers with and without optimization.
 
 ## Blogs of Developers
-  * [Coding Horror](http://blog.codinghorror.com/) : one the best coding blog
-  * [WildMl](http://www.wildml.com/) : A blog for machine learning.
-  * [Armin Ronacher's Thoughts and Writings](http://lucumr.pocoo.org/) : blog on Python and open source
-  * [Eli Bendersky](http://eli.thegreenplace.net/) : everything from Python to LLVM
-  * [Joel on Software](http://joelonsoftware.com/)
-  * [ Stephen Haunts { Coding in the Trenches } ](https://stephenhaunts.com/)
-  * [Programming in the 21st Century](http://prog21.dadgum.com/)
-  * [Clean Coder Blog  ](http://blog.cleancoder.com/) : blog of author of book "Clean Code"
-  * [Programming Blog](http://www.yegor256.com/) : programming blog of Yegor Bugayenko
-  * [CodeAhoy](https://codeahoy.com) : Blog on software and human factors. 100% Tested on Humans.
-  * [http://stevehanov.ca/blog/ ](http://stevehanov.ca/blog/)
-  * [Geek Land ](https://avidullu.wordpress.com/)
-  * [Late Developer ](https://latedev.wordpress.com/)
-  * [IT Enthusiast ](http://rodiongork.tumblr.com/)
-  * [blog.might.net ](http://matt.might.net/articles/)
-  * [CSE Blog - quant, math, computer science puzzles ](http://www.cseblog.com/)
-  * [Small Programming Challenges and Puzzles](https://www.nayuki.io/category/programming)
-  * [My Tech Interviews ](http://www.mytechinterviews.com/)
-  * [HackerEarth Blog ](http://blog.hackerearth.com/)
-  * [Algo-Geeks ](http://algo-geeks.blogspot.in/)
-  * [CoderGears Blog Insights from ](http://www.codergears.com/Blog/) : the CoderGears Team
-  * [Runhe Tian Coding Practice ](https://tianrunhe.wordpress.com/)
-  * [Paul Graham Essays ](http://www.paulgraham.com/articles.html)
-  * [Dan Dreams of Coding ](http://dandreamsofcoding.com/)
-  * [Antonio081014's Algorithms Codes ](http://code.antonio081014.com/)
-  * [Math ∩ Programming](http://jeremykun.com/)
-  * [Takipi Blog ](http://blog.takipi.com/) : mainly focuses on Java and JVM languages
-  * [Coding Geek - A blog about IT, programming and Java ](http://coding-geek.com/)
-  * [Daedtech.com ](http://www.daedtech.com/) : Stories about software
-  * [Archives — Ask a Manager ](http://www.askamanager.org/archives) : HR related stuff
+- [Coding Horror](http://blog.codinghorror.com/) : one the best coding blog
+- [WildMl](http://www.wildml.com/) : A blog for machine learning.
+- [Armin Ronacher's Thoughts and Writings](http://lucumr.pocoo.org/) : blog on Python and open source
+- [Eli Bendersky](http://eli.thegreenplace.net/) : everything from Python to LLVM
+- [Joel on Software](http://joelonsoftware.com/)
+- [ Stephen Haunts { Coding in the Trenches } ](https://stephenhaunts.com/)
+- [Programming in the 21st Century](http://prog21.dadgum.com/)
+- [Clean Coder Blog  ](http://blog.cleancoder.com/) : blog of author of book "Clean Code"
+- [Programming Blog](http://www.yegor256.com/) : programming blog of Yegor Bugayenko
+- [CodeAhoy](https://codeahoy.com) : Blog on software and human factors. 100% Tested on Humans.
+- [http://stevehanov.ca/blog/ ](http://stevehanov.ca/blog/)
+- [Geek Land ](https://avidullu.wordpress.com/)
+- [Late Developer ](https://latedev.wordpress.com/)
+- [IT Enthusiast ](http://rodiongork.tumblr.com/)
+- [blog.might.net ](http://matt.might.net/articles/)
+- [CSE Blog - quant, math, computer science puzzles ](http://www.cseblog.com/)
+- [Small Programming Challenges and Puzzles](https://www.nayuki.io/category/programming)
+- [My Tech Interviews ](http://www.mytechinterviews.com/)
+- [HackerEarth Blog ](http://blog.hackerearth.com/)
+- [Algo-Geeks ](http://algo-geeks.blogspot.in/)
+- [CoderGears Blog Insights from ](http://www.codergears.com/Blog/) : the CoderGears Team
+- [Runhe Tian Coding Practice ](https://tianrunhe.wordpress.com/)
+- [Paul Graham Essays ](http://www.paulgraham.com/articles.html)
+- [Dan Dreams of Coding ](http://dandreamsofcoding.com/)
+- [Antonio081014's Algorithms Codes ](http://code.antonio081014.com/)
+- [Math ∩ Programming](http://jeremykun.com/)
+- [Takipi Blog ](http://blog.takipi.com/) : mainly focuses on Java and JVM languages
+- [Coding Geek - A blog about IT, programming and Java ](http://coding-geek.com/)
+- [Daedtech.com ](http://www.daedtech.com/) : Stories about software
+- [Archives — Ask a Manager ](http://www.askamanager.org/archives) : HR related stuff
 
 ## For improving your English
-  * [Quia - English ](https://www.quia.com/shared/english/)
-  * [Punctuation and Capitalization Rules](http://www.grammarbook.com/english_rules.asp)
-  * [Guide to Grammar and Writing](http://grammar.ccc.commnet.edu/grammar/)
-  * [Purdue University Online Writing Lab (OWL) ](https://owl.english.purdue.edu/)
-  * [Englishclub.com/learn-english](https://www.englishclub.com/learn-english.htm)
+- [Quia - English ](https://www.quia.com/shared/english/)
+- [Punctuation and Capitalization Rules](http://www.grammarbook.com/english_rules.asp)
+- [Guide to Grammar and Writing](http://grammar.ccc.commnet.edu/grammar/)
+- [Purdue University Online Writing Lab (OWL) ](https://owl.english.purdue.edu/)
+- [Englishclub.com/learn-english](https://www.englishclub.com/learn-english.htm)
 
 ## When you get bored from CS related stuff
 
-  * [r/ProgrammerHumor](https://www.reddit.com/r/ProgrammerHumor/) : Subreddit dedicated to exactly what it sounds like
-  * [Guide to Grammar and Writing](http://grammar.ccc.commnet.edu/grammar/) for those who want to improve their english language skills
-  * [Vsauce ](https://www.youtube.com/user/Vsauce/videos) : The best youtube channel
-  * [TED ](https://www.youtube.com/user/TEDtalksDirector/videos) : Great talks about technology, entertainment, and design
-  * [CrashCourse ](https://www.youtube.com/user/crashcourse/videos) : small courses on various subjects
-  * [National Geographic ](https://www.youtube.com/user/NationalGeographic/videos) : High volume of high quality content from all over the world
-  * [Barcroft TV](https://www.youtube.com/user/barcroftmedia/featured) : Daily short documentaries about the incredible variety of people that make up the world
-  * [ColdFusion ](https://www.youtube.com/user/coldfustion/videos) : Past, present, and future of technology
-  * [SmarterEveryDay ](https://www.youtube.com/user/destinws2/videos) : Lots of amazing scientific information about the world around us, usually captured with a high-speed camera
-  * [SciShow ](https://www.youtube.com/user/scishow/videos) : Answers to interesting questions that you've always wondered about
-  * [Big Think](https://www.youtube.com/user/bigthink/videos) : Expert driven, actionable, educational content, featuring experts ranging from Bill Clinton to Bill Nye
-  * [Every Frame a Painting ](https://www.youtube.com/user/everyframeapainting/videos) : High quality analysis of films and filmmaking
-  * [TestTube News](https://www.youtube.com/user/TestTubeNetwork/videos) : Interesting information about news from around the world
-  * [Reddit the front page of the internet](http://reddit.com/) : Where free time goes to die
+- [r/ProgrammerHumor](https://www.reddit.com/r/ProgrammerHumor/) : Subreddit dedicated to exactly what it sounds like
+- [Guide to Grammar and Writing](http://grammar.ccc.commnet.edu/grammar/) for those who want to improve their english language skills
+- [Vsauce ](https://www.youtube.com/user/Vsauce/videos) : The best youtube channel
+- [TED ](https://www.youtube.com/user/TEDtalksDirector/videos) : Great talks about technology, entertainment, and design
+- [CrashCourse ](https://www.youtube.com/user/crashcourse/videos) : small courses on various subjects
+- [National Geographic ](https://www.youtube.com/user/NationalGeographic/videos) : High volume of high quality content from all over the world
+- [Barcroft TV](https://www.youtube.com/user/barcroftmedia/featured) : Daily short documentaries about the incredible variety of people that make up the world
+- [ColdFusion ](https://www.youtube.com/user/coldfustion/videos) : Past, present, and future of technology
+- [SmarterEveryDay ](https://www.youtube.com/user/destinws2/videos) : Lots of amazing scientific information about the world around us, usually captured with a high-speed camera
+- [SciShow ](https://www.youtube.com/user/scishow/videos) : Answers to interesting questions that you've always wondered about
+- [Big Think](https://www.youtube.com/user/bigthink/videos) : Expert driven, actionable, educational content, featuring experts ranging from Bill Clinton to Bill Nye
+- [Every Frame a Painting ](https://www.youtube.com/user/everyframeapainting/videos) : High quality analysis of films and filmmaking
+- [TestTube News](https://www.youtube.com/user/TestTubeNetwork/videos) : Interesting information about news from around the world
+- [Reddit the front page of the internet](http://reddit.com/) : Where free time goes to die
 
   ___Maintained with :heart: by sdmg15 & al___

--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ When learning CS there are some useful sites you must know to get always informe
 - [vicky002/1000-Projects](https://github.com/vicky002/1000_Projects) : Mega List of practical projects that one can solve in any programming language!
 
 ## General Coding advice
-- [Things I Wish Someone Had Told Me When I Was Learning How to Code — Free Code Camp](https://medium.freecodecamp.com/things-i-wish-someone-had-told-me-when-i-was-learning-how-to-code-565fc9dcb329?gi=463de842ab80)
+- [Things I Wish Someone Had Told Me When I Was Learning How to Code — Free Code Camp](https://medium.freecodecamp.com/things-i-wish-someone-had-told-me-when-i-was-learning-how-to-code-565fc9dcb329)
 - [Lessons From A Lifetime Of Being A Programmer](http://thecodist.com/article/lessons_from_a_lifetime_of_being_a_programmer)
 - [Principles of Good Programming](http://www.artima.com/weblogs/viewpost.jsp?thread=331531)
-- [What every computer science major should know](http://matt.might.net/articles/what-cs-majors-should-know)
+- [What every computer science major should know](http://matt.might.net/articles/what-cs-majors-should-know/)
 - [How to become a programmer, or the art of Googling well](https://okepi.wordpress.com/2014/08/21/how-to-become-a-programmer-or-the-art-of-googling-well/)
 - [Code Review Best Practices](https://www.kevinlondon.com/2015/05/05/code-review-best-practices.html)
 - [Dieter Rams : 10 Principles of Good Product Design](https://stephenhaunts.com/2013/12/11/dieter-rams-10-principles-of-good-product-design/)
@@ -122,7 +122,7 @@ When learning CS there are some useful sites you must know to get always informe
 - [Delightful Puzzles](http://gurmeet.net/puzzles/)
 - [visualising data structures and algorithms through animation](https://visualgo.net/en)
 - [Here's How to Prepare for Tech Interviews • /r/cscareerquestions](https://www.reddit.com/r/cscareerquestions/comments/1jov24/heres_how_to_prepare_for_tech_interviews/)
-- [Guide to Tech Interviews](https://www.kchodorow.com/blog/2013/02/28/guide-to-tech-interviews)
+- [Guide to Tech Interviews](https://www.kchodorow.com/blog/2013/02/28/guide-to-tech-interviews/)
 - [Why You Make Less Money • /r/cscareerquestions](https://www.reddit.com/r/cscareerquestions/comments/1b8wa3/why_you_make_less_money/)
 - [IIT Delhi Placement Experience](http://placement-iit2013.blogspot.in)
 - [what_are_your_goto_questions_for_the_do_you_have?](https://www.reddit.com/r/cscareerquestions/comments/209rkq/what_are_your_goto_questions_for_the_do_you_have/)
@@ -148,7 +148,7 @@ When learning CS there are some useful sites you must know to get always informe
 - [Mission-peace/interview problems](https://github.com/mission-peace/interview/wiki) : A large collection of coding interview problems
 - [SQL Joins explained using venn diagram](http://stevestedman.com/wp-content/uploads/VennDiagram1.pdf)
 - [10 Frequently asked SQL Query Interview Questions](http://www.java67.com/2013/04/10-frequently-asked-sql-query-interview-questions-answers-database.html)
-- [Get Ready to Learn SQL: 8. Database Normalization Explained in Simple English - Essential SQL](https://www.essentialsql.com/get-ready-to-learn-sql-database-normalization-explained-in-simple-english)
+- [Get Ready to Learn SQL: 8. Database Normalization Explained in Simple English - Essential SQL](https://www.essentialsql.com/get-ready-to-learn-sql-database-normalization-explained-in-simple-english/)
 - [Programming Language Concepts: Lecture Notes](http://www.cmi.ac.in/~madhavan/courses/pl2006/lecturenotes/lecture-notes/lecture-notes.html) : OOPs concepts and programming language concepts.
 - [We Help Coders Get Hired](https://www.hiredintech.com/app) : website offering courses on system design, interview strategies, soft skills etc
 - [checkcheckzz/system-design-interview](https://github.com/checkcheckzz/system-design-interview)
@@ -188,7 +188,7 @@ When learning CS there are some useful sites you must know to get always informe
 ## MOOCs for learning something new
 - [Class Central](https://www.class-central.com) : a directory of 100,000+ student reviews of thousands of MOOCs.
 - [NPTEL Vidoes COMP_SCI_ENGG](https://onlinecourses.nptel.ac.in/explorer/search?category=COMP_SCI_ENGG)
-- [Coursera.org](https://coursera.org/)
+- [Coursera.org](https://www.coursera.org)
 - [edX](https://www.edx.org)
 - [MOOC.fi](http://mooc.fi/english.html) : Free online courses from the University of Helsinki
 - [Udacity](https://www.udacity.com)
@@ -313,27 +313,27 @@ When learning CS there are some useful sites you must know to get always informe
 - [CMSI 281: Data Structures](http://cs.lmu.edu/~ray/classes/dsa/) : light weight introduction to DS
 - [How to Program in C++](http://cs.fit.edu/~mmahoney/cse2050/how2cpp.html) : Good resource for revising C++ topics and STL
 - [TopCoder Tutorials](https://www.topcoder.com/community/data-science/data-science-tutorials/)
-- [A Hacker's Guide to Git](http://wildlyinaccurate.com/a-hackers-guide-to-git) : for those wanting to learn git with a solid foundation
+- [A Hacker's Guide to Git](https://wildlyinaccurate.com/a-hackers-guide-to-git) : for those wanting to learn git with a solid foundation
 - [Git from the inside out](https://maryrosecook.com/blog/post/git-from-the-inside-out)
 - [Learn UNIX in 10 minutes](http://freeengineer.org/learnUNIXin10minutes.html)
 - [The Bash Guide](http://guide.bash.academy) : very good guide for learning the Bash Shell
 - [Linux Tutorial](http://ryanstutorials.net/linuxtutorial/) : good resource for learning Linux
 - [UNIX Tutorial - Introduction](http://www.ee.surrey.ac.uk/Teaching/Unix/unixintro.html)
-- [Linux Tutorial for Beginners](http://www.ee.surrey.ac.uk/Teaching/Unix)
+- [Linux Tutorial for Beginners](http://www.ee.surrey.ac.uk/Teaching/Unix/)
 - [Learning the shell.](http://linuxcommand.org/learning_the_shell.php)
 - [Dynamic programming - PrismoSkills](http://prismoskills.appspot.com/lessons/Dynamic_Programming/Chapter_01_-_Introduction.jsp) : very good resource if want to learn how to solve DP problems.
 - [Deep C](https://www.slideshare.net/olvemaudal/deep-c) : very good presentation on C language
 - [C programming language Frequently Asked Questions](http://c-faq.com/index.html)
-- [OS Course Notes](https://www.cs.uic.edu/~jbell/CourseNotes/OperatingSystems) : Chapter wise course notes according to Galvin's book
-- [SQL (Structured Query Language) in one page : SQL.SU](http://www.cheat-sheets.org/sites/sql.su) : a very good SQL cheat sheet
+- [OS Course Notes](https://www2.cs.uic.edu/~jbell/CourseNotes/OperatingSystems/) : Chapter wise course notes according to Galvin's book
+- [SQL (Structured Query Language) in one page : SQL.SU](http://www.cheat-sheets.org/sites/sql.su/) : a very good SQL cheat sheet
 - [Introduction to C Programming](http://www.le.ac.uk/users/rjm1/cotter/index.htm)
 - [MySQL Essentials](http://www.techotopia.com/index.php/MySQL_Essentials)
 - [http://www.mysqltutorial.org/](http://www.mysqltutorial.org)
-- [Best Of - Gustavo Duarte](http://duartes.org/gustavo/blog/best-of) : contains articles on various topics
+- [Best Of - Gustavo Duarte](http://duartes.org/gustavo/blog/best-of/) : contains articles on various topics
 - [Collecting all the cheat sheets](http://overapi.com) : cheat sheets for lots of programming languages
-- [The Descent to C](https://www.chiark.greenend.org.uk/~sgtatham/cdescent) : for those moving to C from some higher programming language like java or python.
+- [The Descent to C](https://www.chiark.greenend.org.uk/~sgtatham/cdescent/) : for those moving to C from some higher programming language like java or python.
 - [VimTutor+](https://vimtutorplus.herokuapp.com/exercise/1) : learn VIM from browser itself
-- [HackerEarth Tutorials](https://learn.hackerearth.com/tutorials) : Good resource for DS and Algos tutorial
+- [HackerEarth Tutorials](https://learn.hackerearth.com/tutorials/) : Good resource for DS and Algos tutorial
 - [Linux Journey](https://linuxjourney.com) : good site for learning linux
 - [C Programming](http://users.cs.cf.ac.uk/Dave.Marshall/C/CE.html)
 - [CS 2112/ENGRD 2112 Fall 2015](http://www.cs.cornell.edu/courses/cs2112/2015fa/lectures/index.html) : Good notes on data structures and algorithms.
@@ -351,7 +351,7 @@ When learning CS there are some useful sites you must know to get always informe
 - [LiveEdu.tv](https://www.liveedu.tv) : screencast of people building application, websites, games, ect.
 
 ## What should a programmer know
-- [Programmer Competency Matrix](http://sijinjoseph.com/programmer-competency-matrix) : article for knowing what our level as a programmer is.
+- [Programmer Competency Matrix](http://sijinjoseph.com/programmer-competency-matrix/) : article for knowing what our level as a programmer is.
 - [GitHub.com Build software better, together](https://github.com) : Place to showcase your project and collaborate with others. (Must know Git in order to use it effectively)
 - [Gitlab offers free unlimited (private) repositories and unlimited collaborators](https://about.gitlab.com).
 
@@ -359,10 +359,10 @@ When learning CS there are some useful sites you must know to get always informe
 - [WakaTime](https://wakatime.com) : leaderboards of coding metrics collected via editor plugins
 - [HackerRank](https://www.hackerrank.com)
 - [Codeforces](http://codeforces.com)
-- [topcoder](http://www.topcoder.com/)
+- [topcoder](https://www.topcoder.com)
 - [UVa Online Judge](https://uva.onlinejudge.org) : hundreds of problems supporting multiple languages.
 - [HackerEarth - Programming challenges and Developer jobs](https://www.hackerearth.com)
-- [CodeChef](http://www.codechef.com/)
+- [CodeChef](https://www.codechef.com)
 - [PKU ACM ICPC Practice problems](http://poj.org/problemlist)
 - [Archived Problems - Project Euler](https://projecteuler.net/archives)
 - [Google Code Jam Practice and](https://code.google.com/codejam/past-contests) : past contest problems for practice
@@ -377,7 +377,7 @@ When learning CS there are some useful sites you must know to get always informe
 - [IT eBooks - Free Download - Big Library](http://it-ebooks.info) : website for downloading ebooks without any advertisement and instant downloads.
 - [github.com/vhf/free-programming-books](https://github.com/EbookFoundation/free-programming-books/blob/master/free-programming-books.md) : More than 500 free ebooks on almost any language you can think of
 - [Computer Science Books Online](http://www.sciencebooksonline.info/computer-science.html) : about 150 computer free ebooks
-- [Best books for GATE CSE](http://www.gatecse.in/best-books-for-gate/)
+- [Best books for GATE CSE](http://gatecse.in/best-books-for-gatecse/)
 - [cses.fi/book.html](https://cses.fi/book.html)
 - [Library Genesis](http://gen.lib.rus.ec) : Almost any ebook you can think of, including countless CS texts and manuals.
 
@@ -408,7 +408,7 @@ When learning CS there are some useful sites you must know to get always informe
 - [WildMl](http://www.wildml.com) : A blog for machine learning.
 - [Armin Ronacher's Thoughts and Writings](http://lucumr.pocoo.org) : blog on Python and open source
 - [Eli Bendersky](http://eli.thegreenplace.net) : everything from Python to LLVM
-- [Joel on Software](http://www.joelonsoftware.com/)
+- [Joel on Software](https://www.joelonsoftware.com)
 - [Stephen Haunts { Coding in the Trenches }](https://stephenhaunts.com)
 - [Programming in the 21st Century](http://prog21.dadgum.com)
 - [Clean Coder Blog](http://blog.cleancoder.com) : blog of author of book "Clean Code"
@@ -418,7 +418,7 @@ When learning CS there are some useful sites you must know to get always informe
 - [Geek Land](https://avidullu.wordpress.com)
 - [Late Developer](https://latedev.wordpress.com)
 - [IT Enthusiast](http://rodiongork.tumblr.com)
-- [blog.might.net](http://matt.might.net/articles)
+- [blog.might.net](http://matt.might.net/articles/)
 - [CSE Blog - quant, math, computer science puzzles](http://www.cseblog.com)
 - [Small Programming Challenges and Puzzles](https://www.nayuki.io/category/programming)
 - [My Tech Interviews](http://www.mytechinterviews.com)

--- a/README.md
+++ b/README.md
@@ -307,8 +307,8 @@ When learning CS there are some useful sites you must know to get always informe
 - [:snowman: Possibly the smallest compiler ever](https://github.com/thejameskyle/the-super-tiny-compiler)
 - [Writing My First Compiler](https://dev.to/fcpauldiaz/writing-my-first-compiler)
 - [Structure and Interpretation of Computer Programs](https://sarabander.github.io/sicp/html/index.xhtml)
--  [Let’s Build A Simple Interpreter. Part 1.](https://ruslanspivak.com/lsbasi-part1)
--  [Growing a compiler](http://www.cs.dartmouth.edu/~mckeeman/cs48/mxcom/gem/html/GrowingCompiler.html)
+- [Let’s Build A Simple Interpreter. Part 1.](https://ruslanspivak.com/lsbasi-part1)
+- [Growing a compiler](http://www.cs.dartmouth.edu/~mckeeman/cs48/mxcom/gem/html/GrowingCompiler.html)
 
 ## Tutorials
 - [Subtle | Poor Man's CI](https://www.subtle.press/course/poor-mans-ci) : Learn how continuous integration platforms work under the hood, by building one of your own on top of git with Node.js

--- a/README.md
+++ b/README.md
@@ -41,37 +41,37 @@ When learning CS there are some useful sites you must know to get always informe
 </ul>
 
 ## When you get stuck
-- [Stack Overflow](http://stackoverflow.com/) : subscribe to their weekly newsletter and any other topic which you find interesting
-- [Quora](https://www.quora.com/) : A place to share knowledge and better understand the world:
-- [Learn Anything](https://learn-anything.xyz/) : Community curated knowledge graph of best paths for learning anything
+- [Stack Overflow](http://stackoverflow.com) : subscribe to their weekly newsletter and any other topic which you find interesting
+- [Quora](https://www.quora.com) : A place to share knowledge and better understand the world:
+- [Learn Anything](https://learn-anything.xyz) : Community curated knowledge graph of best paths for learning anything
 
 ## News
-- [Hacker News](https://news.ycombinator.com/) : news aggregator for programmers where civility is king, try a newsletter to get top news to your inbox:
-- [Hacker Newsletter](http://www.hackernewsletter.com/) : curated by hand, delivered weekly
-- [Hacker News Digest](https://hndigest.com/) : curated automatically, delivered as frequently as you want
-- [Ars Technica](http://arstechnica.com/) : posts unique quality articles
-- [ACM TechNews](http://technews.acm.org/)
-- [Lobsters](https://lobste.rs/) : Lobsters is a technology-focused community centered around link aggregation and discussion.
-- [TechCrunch](http://techcrunch.com/) : another good website for tech news
-- [GSMArena.com](http://gsmarena.com/) : news related to latest mobile phones and android.
-- [product hunt ](https://www.producthunt.com/) : Discover your next favorite thing
+- [Hacker News](https://news.ycombinator.com) : news aggregator for programmers where civility is king, try a newsletter to get top news to your inbox:
+- [Hacker Newsletter](http://www.hackernewsletter.com) : curated by hand, delivered weekly
+- [Hacker News Digest](https://hndigest.com) : curated automatically, delivered as frequently as you want
+- [Ars Technica](http://arstechnica.com) : posts unique quality articles
+- [ACM TechNews](http://technews.acm.org)
+- [Lobsters](https://lobste.rs) : Lobsters is a technology-focused community centered around link aggregation and discussion.
+- [TechCrunch](http://techcrunch.com) : another good website for tech news
+- [GSMArena.com](http://gsmarena.com) : news related to latest mobile phones and android.
+- [product hunt ](https://www.producthunt.com) : Discover your next favorite thing
 - [AlternativeTo](https://alternativeto.net) : Crowdsourced software recommendations
 - [Better Dev Links](https://betterdev.link) : Weekly links to help you become a better developer
 
 ## Coding practice for beginners
-- [freeCodeCamp](https://www.freecodecamp.com/) : Learn to code and build projects for nonprofits. Build your full stack web development portfolio today
+- [freeCodeCamp](https://www.freecodecamp.com) : Learn to code and build projects for nonprofits. Build your full stack web development portfolio today
 - [Reddit.com/r/dailyprogrammer](http://www.reddit.com/r/dailyprogrammer) : interesting programming challenges where you can learn from looking at other's code , even if you are not able to solve code you can look at how others solved.
-- [Programming by Doing](http://programmingbydoing.com/) : very good site for those who want to start with absolute basics
-- [CodeAbbey - a place where everyone can master programming](http://codeabbey.com/) : Best place to begin with problems that start at the easiest and gradually increase difficulty with each problem.
-- [Exercism.io](http://exercism.io/) : download and solve practice problems in over 30 different languages, and share your solution with others.
+- [Programming by Doing](http://programmingbydoing.com) : very good site for those who want to start with absolute basics
+- [CodeAbbey - a place where everyone can master programming](http://codeabbey.com) : Best place to begin with problems that start at the easiest and gradually increase difficulty with each problem.
+- [Exercism.io](http://exercism.io) : download and solve practice problems in over 30 different languages, and share your solution with others.
 - [Programming Tasks](http://rosettacode.org/wiki/Category:Programming_Tasks) : large collection of small programs
 - [karan/Projects-Solutions](https://github.com/karan/Projects-Solutions) Solutions to most of the problems in the link above
-- [Lod - Cloud](http://lod-cloud.net/) : The Linking Open Data cloud diagram
-- [Cave of programming](https://caveofprogramming.com/) : Learn to program, Upgrade your skills.
-- [Codeacademy](https://www.codecademy.com/) : Learn to code interactively, for free.
+- [Lod - Cloud](http://lod-cloud.net) : The Linking Open Data cloud diagram
+- [Cave of programming](https://caveofprogramming.com) : Learn to program, Upgrade your skills.
+- [Codeacademy](https://www.codecademy.com) : Learn to code interactively, for free.
 
 ## For those who want to start a small project but can't find the ideas
-- [martyr2s-mega-project-ideas-list](http://www.dreamincode.net/forums/topic/78802-martyr2s-mega-project-ideas-list/) : contains about 125 project ideas from beginner to intermediate level.
+- [martyr2s-mega-project-ideas-list](http://www.dreamincode.net/forums/topic/78802-martyr2s-mega-project-ideas-list) : contains about 125 project ideas from beginner to intermediate level.
 - [karan/Projects](https://github.com/karan/Projects) : a large collection of small projects for beginners with
 - [Wrong "big projects" for beginners](http://rodiongork.tumblr.com/post/108155476418/wrong-big-projects-for-beginners) : How to choose where to start
 - [vicky002/1000-Projects](https://github.com/vicky002/1000_Projects) : Mega List of practical projects that one can solve in any programming language!
@@ -80,12 +80,12 @@ When learning CS there are some useful sites you must know to get always informe
 - [Things I Wish Someone Had Told Me When I Was Learning How to Code — Free Code Camp](https://medium.freecodecamp.com/things-i-wish-someone-had-told-me-when-i-was-learning-how-to-code-565fc9dcb329#.y5wbd3pj6)
 - [Lessons From A Lifetime Of Being A Programmer](http://thecodist.com/article/lessons_from_a_lifetime_of_being_a_programmer)
 - [Principles of Good Programming](http://www.artima.com/weblogs/viewpost.jsp?thread=331531)
-- [What every computer science major should know](http://matt.might.net/articles/what-cs-majors-should-know/)
-- [How to become a programmer, or the art of Googling well](https://okepi.wordpress.com/2014/08/21/how-to-become-a-programmer-or-the-art-of-googling-well/)
+- [What every computer science major should know](http://matt.might.net/articles/what-cs-majors-should-know)
+- [How to become a programmer, or the art of Googling well](https://okepi.wordpress.com/2014/08/21/how-to-become-a-programmer-or-the-art-of-googling-well)
 - [Code Review Best Practices](http://kevinlondon.com/2015/05/05/code-review-best-practices.html)
-- [Dieter Rams : 10 Principles of Good Product Design](https://stephenhaunts.com/2013/12/11/dieter-rams-10-principles-of-good-product-design/)
+- [Dieter Rams : 10 Principles of Good Product Design](https://stephenhaunts.com/2013/12/11/dieter-rams-10-principles-of-good-product-design)
 - [10-ways-to-be-a-better-developer](https://stephenhaunts.files.wordpress.com/2014/04/10-ways-to-be-a-better-developer.png)
-- [Working as a Software Developer](https://henrikwarne.com/2012/12/12/working-as-a-software-developer/)
+- [Working as a Software Developer](https://henrikwarne.com/2012/12/12/working-as-a-software-developer)
 - [Software design pattern](https://en.wikipedia.org/wiki/Software_design_pattern) : The entire collection of Design Patterns.
 - [Design Patterns](https://sourcemaking.com/design_patterns) : Design Patterns explained in detail with examples.
 
@@ -93,11 +93,11 @@ When learning CS there are some useful sites you must know to get always informe
 - [CS 106B Coding Style Guide](http://stanford.edu/class/archive/cs/cs106b/cs106b.1158/styleguide.shtml) : must see for those who create spaghetti
 - [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html)
 - [Airbnb JS Style Guide](https://github.com/airbnb/javascript) : A mostly reasonable approach to JavaScript
-- [What are some bad coding habits you would recommend a beginner avoid getting into?](https://www.reddit.com/r/learnprogramming/comments/1i4ds4/what_are_some_bad_coding_habits_you_would/)
-- [Good C programming habits. • /r/C_Programming](https://www.reddit.com/r/C_Programming/comments/1vuubw/good_c_programming_habits/)
+- [What are some bad coding habits you would recommend a beginner avoid getting into?](https://www.reddit.com/r/learnprogramming/comments/1i4ds4/what_are_some_bad_coding_habits_you_would)
+- [Good C programming habits. • /r/C_Programming](https://www.reddit.com/r/C_Programming/comments/1vuubw/good_c_programming_habits)
 - [How to Report Bugs Effectively](http://www.chiark.greenend.org.uk/~sgtatham/bugs.html)
 - [Debugging Faqs](http://www.umich.edu/~eecs381/generalFAQ/Debugging.html)
-- [Stuff you need to Code Better!](http://codebetter.com/)
+- [Stuff you need to Code Better!](http://codebetter.com)
 - [Directory of Online CS Courses](https://github.com/open-source-society/computer-science)
 - [Directory of CS Courses (many with online lectures)](https://github.com/prakhar1989/awesome-courses)
 - [Angular 1 Style Guide](https://github.com/johnpapa/angular-styleguide/tree/master/a1) : Officially endorsed style guide by John Pappa
@@ -105,64 +105,64 @@ When learning CS there are some useful sites you must know to get always informe
 ## General Tools
 
 ### Interview Preparation
-- [GeeksforGeeks | A computer science portal for geeks](http://www.geeksforgeeks.org/) : also subscribe to their feeds to get links to their new articles.
-- [A site for technical interview questions, brain teasers, puzzles, quizzles](http://www.techinterview.org/) : whatever the heck those are) and other things that make you think!
-- [Problems | LeetCode OJ ](https://leetcode.com/problemset/algorithms/) : Coding practice for interviews
-- [Programmer And Software Interview Questions Answers](http://www.programmerinterview.com/)
+- [GeeksforGeeks | A computer science portal for geeks](http://www.geeksforgeeks.org) : also subscribe to their feeds to get links to their new articles.
+- [A site for technical interview questions, brain teasers, puzzles, quizzles](http://www.techinterview.org) : whatever the heck those are) and other things that make you think!
+- [Problems | LeetCode OJ ](https://leetcode.com/problemset/algorithms) : Coding practice for interviews
+- [Programmer And Software Interview Questions Answers](http://www.programmerinterview.com)
 - [Reddit.com/user/ashish2199/m/puzzles](https://www.reddit.com/user/ashish2199/m/puzzles) : Logic Puzzles
-- [A Collection of Quant Riddles With Answers](http://puzzles.nigelcoldwell.co.uk/)
-- [Aptitude Questions and Answers](http://www.indiabix.com/) : Quant and aptitude preparation
-- [Interview Archives - Java Honk](http://javahonk.com/category/interview/)
-- [Top 10 Algorithms for Coding Interview](http://www.programcreek.com/2012/11/top-10-algorithms-for-coding-interview/)
-- [Algorithm design canvas](http://www.hiredintech.com/algorithm-design/))
+- [A Collection of Quant Riddles With Answers](http://puzzles.nigelcoldwell.co.uk)
+- [Aptitude Questions and Answers](http://www.indiabix.com) : Quant and aptitude preparation
+- [Interview Archives - Java Honk](http://javahonk.com/category/interview)
+- [Top 10 Algorithms for Coding Interview](http://www.programcreek.com/2012/11/top-10-algorithms-for-coding-interview)
+- [Algorithm design canvas](http://www.hiredintech.com/algorithm-design))
 - [Big-O Algorithm Complexity Cheat Sheet](http://bigocheatsheet.com/#)
-- [Unix / Linux Cheat Sheet](http://cheatsheetworld.com/programming/unix-linux-cheat-sheet/)
+- [Unix / Linux Cheat Sheet](http://cheatsheetworld.com/programming/unix-linux-cheat-sheet)
 - [How to interview](http://kelukelu.me/interview/index.html)
-- [How to Ace an Algorithms Interview](http://www.palantir.com/2011/09/how-to-rock-an-algorithms-interview/)
-- [Delightful Puzzles ](http://gurmeet.net/puzzles/)
-- [visualising data structures and algorithms through animation](http://visualgo.net/)
-- [Here's How to Prepare for Tech Interviews • /r/cscareerquestions](https://www.reddit.com/r/cscareerquestions/comments/1jov24/heres_how_to_prepare_for_tech_interviews/)
-- [Guide to Tech Interviews](http://www.kchodorow.com/blog/2013/02/28/guide-to-tech-interviews/)
-- [Why You Make Less Money • /r/cscareerquestions](https://www.reddit.com/r/cscareerquestions/comments/1b8wa3/why_you_make_less_money/)
-- [IIT Delhi Placement Experience](http://placement-iit2013.blogspot.in/)
-- [what_are_your_goto_questions_for_the_do_you_have?](https://www.reddit.com/r/cscareerquestions/comments/209rkq/what_are_your_goto_questions_for_the_do_you_have/)
-- [/r/cscareerquestions](https://www.reddit.com/r/cscareerquestions/comments/20ahfq/heres_a_pretty_big_list_of_programming_interview/) : Here's a pretty big list of programming interview questions I compiled while studying for big 4 interviews. I think you guys will find it useful! •
-- [Interviewing At Jane Street](https://blogs.janestreet.com/interviewing-at-jane-street/)
+- [How to Ace an Algorithms Interview](http://www.palantir.com/2011/09/how-to-rock-an-algorithms-interview)
+- [Delightful Puzzles ](http://gurmeet.net/puzzles)
+- [visualising data structures and algorithms through animation](http://visualgo.net)
+- [Here's How to Prepare for Tech Interviews • /r/cscareerquestions](https://www.reddit.com/r/cscareerquestions/comments/1jov24/heres_how_to_prepare_for_tech_interviews)
+- [Guide to Tech Interviews](http://www.kchodorow.com/blog/2013/02/28/guide-to-tech-interviews)
+- [Why You Make Less Money • /r/cscareerquestions](https://www.reddit.com/r/cscareerquestions/comments/1b8wa3/why_you_make_less_money)
+- [IIT Delhi Placement Experience](http://placement-iit2013.blogspot.in)
+- [what_are_your_goto_questions_for_the_do_you_have?](https://www.reddit.com/r/cscareerquestions/comments/209rkq/what_are_your_goto_questions_for_the_do_you_have)
+- [/r/cscareerquestions](https://www.reddit.com/r/cscareerquestions/comments/20ahfq/heres_a_pretty_big_list_of_programming_interview) : Here's a pretty big list of programming interview questions I compiled while studying for big 4 interviews. I think you guys will find it useful! •
+- [Interviewing At Jane Street](https://blogs.janestreet.com/interviewing-at-jane-street)
 - [How to prepare for an interview - 1](http://se7so.blogspot.in/2014/01/how-to-prepare-for-interview-1.html)
 - [Summer Internship: The Ultimate Guide](eulercoder.me/blog/career/Summer-Internship-the-ultimate-guide)
 - [The 25 most difficult HR questions ](http://www.datsi.fi.upm.es/~frosal/docs/25mdq.html)
 - [Job interviews News, Videos, Reviews and Gossip - Lifehacker ](http://lifehacker.com/tag/job-interviews)
-- [How to Answer the Toughest 40 Job Interview Questions | ICS Job Portal ](http://www.icsjobportal.com/blog/job-interview-questions/)
+- [How to Answer the Toughest 40 Job Interview Questions | ICS Job Portal ](http://www.icsjobportal.com/blog/job-interview-questions)
 - [Job Interview Questions and Best Answers ](http://jobsearch.about.com/od/interviewquestionsanswers/a/interviewquest.htm)
-- [How to Answer "Tell Me a Little About Yourself" | The Art of Manliness ](http://www.artofmanliness.com/2016/01/05/tell-me-a-little-about-yourself/)
-- [Job Interview: How to Ace a Job Interview | The Art of Manliness ](http://www.artofmanliness.com/2012/08/06/how-to-ace-a-job-interview/)
-- [Give your résumé a face lift ](http://www.lifeclever.com/give-your-resume-a-face-lift/)
+- [How to Answer "Tell Me a Little About Yourself" | The Art of Manliness ](http://www.artofmanliness.com/2016/01/05/tell-me-a-little-about-yourself)
+- [Job Interview: How to Ace a Job Interview | The Art of Manliness ](http://www.artofmanliness.com/2012/08/06/how-to-ace-a-job-interview)
+- [Give your résumé a face lift ](http://www.lifeclever.com/give-your-resume-a-face-lift)
 - [BIG O Misconceptions ](http://ssp.impulsetrain.com/big-o.html)
 - [Bitwise tricks ](https://gist.github.com/dideler/2365607)
-- [Core Java Interview questions - Interview question on each topic ](http://javahonk.com/core-java-interview-questions/)
+- [Core Java Interview questions - Interview question on each topic ](http://javahonk.com/core-java-interview-questions)
 - [Java Interview Questions and Answers ](http://adnjavainterview.blogspot.in)
-- [Big collection of interview preparation links • /r/cscareerquestions ](https://www.reddit.com/r/cscareerquestions/comments/2lzc4h/big_collection_of_interview_preparation_links/)
-- [Unsolicited_advice_for_job_seekers_and_employers ](https://www.reddit.com/r/india/comments/1clgdj/unsolicited_advice_for_job_seekers_and_employers/)
+- [Big collection of interview preparation links • /r/cscareerquestions ](https://www.reddit.com/r/cscareerquestions/comments/2lzc4h/big_collection_of_interview_preparation_links)
+- [Unsolicited_advice_for_job_seekers_and_employers ](https://www.reddit.com/r/india/comments/1clgdj/unsolicited_advice_for_job_seekers_and_employers)
 - [five-essential-phone-screen-questions - steveyegge2 ](https://sites.google.com/site/steveyegge2/five-essential-phone-screen-questions)
-- [CS9: Problem-Solving for the CS Technical Interview ](http://web.stanford.edu/class/cs9/)
+- [CS9: Problem-Solving for the CS Technical Interview ](http://web.stanford.edu/class/cs9)
 - [Mission-peace/interview problems ](https://github.com/mission-peace/interview/wiki) : A large collection of coding interview problems
 - [SQL Joins explained using venn diagram ](http://stevestedman.com/wp-content/uploads/VennDiagram1.pdf)
 - [10 Frequently asked SQL Query Interview Questions ](http://java67.blogspot.in/2013/04/10-frequently-asked-sql-query-interview-questions-answers-database.html)
-- [Get Ready to Learn SQL: 8. Database Normalization Explained in Simple English - Essential SQL ](http://www.essentialsql.com/get-ready-to-learn-sql-database-normalization-explained-in-simple-english/)
+- [Get Ready to Learn SQL: 8. Database Normalization Explained in Simple English - Essential SQL ](http://www.essentialsql.com/get-ready-to-learn-sql-database-normalization-explained-in-simple-english)
 - [Programming Language Concepts: Lecture Notes ](http://www.cmi.ac.in/~madhavan/courses/pl2006/lecturenotes/lecture-notes/lecture-notes.html) : OOPs concepts and programming language concepts.
 - [We Help Coders Get Hired](http://www.hiredintech.com/app) : website offering courses on system design, interview strategies, soft skills etc
 - [checkcheckzz/system-design-interview](https://github.com/checkcheckzz/system-design-interview)
-- [How to Break Into the Tech Industry - a Guide to Job Hunting and Tech Interviews ](http://haseebq.com/how-to-break-into-tech-job-hunting-and-interviews/)
-- [Freshers Interviews](http://placementsindia.blogspot.in/)
+- [How to Break Into the Tech Industry - a Guide to Job Hunting and Tech Interviews ](http://haseebq.com/how-to-break-into-tech-job-hunting-and-interviews)
+- [Freshers Interviews](http://placementsindia.blogspot.in)
 - [C PUZZLES, Some interesting C problems ](http://www.gowrikumar.com/c/index.php)
-- [A site for technical interview questions, brain teasers, puzzles, quizzles (whatever the heck those are) and other things that make you think! ](http://www.techinterview.org/)
+- [A site for technical interview questions, brain teasers, puzzles, quizzles (whatever the heck those are) and other things that make you think! ](http://www.techinterview.org)
 - [ wu :: riddles(hard) ](https://www.ocf.berkeley.edu/~wwu/riddles/hard.shtml) : logic puzzles and riddles
 - [https://github.com/odino/interviews](https://github.com/odino/interviews) : list of important questions for interview
 - [svozniuk/java-interviews](https://github.com/svozniuk/java-interviews) : Java interview questions
 - [kimberli/interviews](https://github.com/kimberli/interviews) : study sheet for Interview
 - [Determining the big-O runtimes of these different loops?](http://stackoverflow.com/questions/11094330/determining-the-big-o-runtimes-of-these-different-loops) : really good stackoverflow question that covers basics of calculating runtime complexity.
 - [ChiperSoft/InterviewThis](https://github.com/ChiperSoft/InterviewThis) : questions to ask during on a interview to know more about the company.
-- [SQL interview questions](https://www.jitbit.com/news/181-jitbits-sql-interview-questions/) : great SQL test
+- [SQL interview questions](https://www.jitbit.com/news/181-jitbits-sql-interview-questions) : great SQL test
 
 ## Documentaries
 - Machine that Changed the World - a very good documentary about history of computers
@@ -177,7 +177,7 @@ When learning CS there are some useful sites you must know to get always informe
 - [Breaking the Code: Biography of Alan Turing ](https://www.youtube.com/watch?v=S23yie-779k)
 - [Mechanical Computer (All Parts) ](https://www.youtube.com/watch?v=s1i-dnAH9Y4) : a very good video from 1950s explaining how mechanical computers used to work without all the modern day electronics.
 - [Download: The True Story of the Internet ](https://www.youtube.com/playlist?list=PL_IlIlrxhtPMqW4b0-v8OgLvFZQes6SoZ) : Play-list of discovery channel documentary on browser wars , dot com bubble and more.
-- [Teach Yourself Computer Science ](https://teachyourselfcs.com/)
+- [Teach Yourself Computer Science ](https://teachyourselfcs.com)
 - [How does CPU execute program (video)](https://www.youtube.com/watch?v=42KTvGYQYnA)
 - [Machine Code Instructions (video)](https://www.youtube.com/watch?v=Mv2XQgpbTNE)
 - [Harvard CS50 - Asymptotic Notation (video)](https://www.youtube.com/watch?v=iOq5kSKqeR4)
@@ -189,34 +189,34 @@ When learning CS there are some useful sites you must know to get always informe
 ## MOOCs for learning something new
 - [Class Central](https://www.class-central.com) : a directory of 100,000+ student reviews of thousands of MOOCs.
 - [NPTEL Vidoes COMP_SCI_ENGG ](https://onlinecourses.nptel.ac.in/explorer/search?category=COMP_SCI_ENGG)
-- [Coursera.org](http://coursera.org/)
-- [edX](http://edx.org/)
+- [Coursera.org](http://coursera.org)
+- [edX](http://edx.org)
 - [MOOC.fi](http://mooc.fi/english.html) : Free online courses from the University of Helsinki
-- [Udacity](http://udacity.com/)
+- [Udacity](http://udacity.com)
 - [Kadenze | Creative Programming](https://www.kadenze.com/courses?subjects%5B%5D=7): Programming courses focused on art and creativity
 - [UCBerkeley](https://www.youtube.com/user/UCBerkeley/videos)
-- [MIT OCW Electrical Engineering and Computer Science](http://ocw.mit.edu/courses/electrical-engineering-and-computer-science/)
+- [MIT OCW Electrical Engineering and Computer Science](http://ocw.mit.edu/courses/electrical-engineering-and-computer-science)
 - [CS50](https://www.youtube.com/user/cs50tv/videos)
 - [prakhar1989/awesome-CS-courses](https://github.com/prakhar1989/awesome-courses/blob/master/README.md) : List containing large amount of CS courses
 - [Computer Science Resources ](https://docs.google.com/spreadsheets/d/1BD8BJJUNaX63m2QmySWMGDp71nx4W4MyyiIBlfMoN3Q/htmlview?sle=true#) : list of MOOCs for autodidacts
 - [https://github.com/prakhar1989/awesome-courses/blob/master/README.md ](https://github.com/prakhar1989/awesome-courses/blob/master/README.md) : collection of CS courses on Internet
 
 ## Sites related to your preferred programming language (For me Java)
-- [Java Revisited ](http://javarevisited.blogspot.in/) : good for learning about Java Language and interview preparation.
-- [The Java™ Tutorials  ](https://docs.oracle.com/javase/tutorial/): The best tutorials for Java.
+- [Java Revisited ](http://javarevisited.blogspot.in) : good for learning about Java Language and interview preparation.
+- [The Java™ Tutorials  ](https://docs.oracle.com/javase/tutorial): The best tutorials for Java.
 - [Java Corner at Artima.com ](http://www.artima.com/java/index.html)
-- [Java Visualizer ](http://www.cs.princeton.edu/~cos126/java_visualize/) : helps visualize references , values of variables ect
-- [Java Lecture Notes ](http://www.cafeaulait.org/course/)
+- [Java Visualizer ](http://www.cs.princeton.edu/~cos126/java_visualize) : helps visualize references , values of variables ect
+- [Java Lecture Notes ](http://www.cafeaulait.org/course)
 - [Learning Java ](http://chimera.labs.oreilly.com/books/1234000001805/index.html) : a free online textbook for learning Java
 - [Free Online Chapters of Inside the Java Virtual Machine by Bill Venners ](http://www.artima.com/insidejvm/ed2/index.html)
-- [Understanding JVM Internals ](http://www.cubrid.org/blog/dev-platform/understanding-jvm-internals/)
+- [Understanding JVM Internals ](http://www.cubrid.org/blog/dev-platform/understanding-jvm-internals)
 - [How Garbage Collection Works ](http://www.dynatrace.com/en/javabook/how-garbage-collection-works.html)
-- [Welcome to JavaWorld.com ](http://www.javaworld.com/)
-- [The Java Memory Model ](http://www.cs.umd.edu/~pugh/java/memoryModel/)
+- [Welcome to JavaWorld.com ](http://www.javaworld.com)
+- [The Java Memory Model ](http://www.cs.umd.edu/~pugh/java/memoryModel)
 - [Netbeans Keyboard Shortcuts ](https://netbeans.org/project_downloads/usersguide/shortcuts-80.pdf) : Keyboard shortcuts to enhance your productivity when working in Netbeans.
 - [XyzWs Java FAQs ](http://www.xyzws.com/javafaq/page/1) : large collection of java interview questions
-- [Search Open Source Java API ](http://www.docjar.com/) : view source of java library and learn how things are implemented.
-- [JournalDev - Java, Java EE, Android, Web Development Tutorials](http://www.journaldev.com/)
+- [Search Open Source Java API ](http://www.docjar.com) : view source of java library and learn how things are implemented.
+- [JournalDev - Java, Java EE, Android, Web Development Tutorials](http://www.journaldev.com)
 - [Implementation of Algorithms and Data Structures, Interview Questions and Answers ](https://github.com/sherxon/AlgoDS)
 - [what-is-garbage-collection](https://plumbr.eu/handbook/what-is-garbage-collection) : Demystify the garbage collection
 - [Best books for learning java must read](https://javahungry.blogspot.com/2014/02/best-books-for-learning-java-must-read.html) : Get basics of Java
@@ -232,16 +232,16 @@ When learning CS there are some useful sites you must know to get always informe
 
 
 ## Learn AI
-- [Unsupervised Sentiment Neuron ](https://blog.openai.com/unsupervised-sentiment-neuron/)
-- [Robots that learn](https://blog.openai.com/robots-that-learn/)
-- [grakn.ai](https://grakn.ai/)
+- [Unsupervised Sentiment Neuron ](https://blog.openai.com/unsupervised-sentiment-neuron)
+- [Robots that learn](https://blog.openai.com/robots-that-learn)
+- [grakn.ai](https://grakn.ai)
 
 ## Seminar , research writing , talks etc
 - [Advice on Research and Writing ](http://www.cs.cmu.edu/~mleone/how-to.html)
 - [Seminar and reports ](https://www.cse.iitb.ac.in/~ranade/communicationskills.html)
 - [PHD MS Articles ](http://www.cse.iitd.ac.in/~srsarangi/articles.html)
-- [Practical Tips for Talking at Usergroups and Conferences ](https://stephenhaunts.com/2015/10/02/practical-tips-for-talking-at-usergroups-and-conferences-part-1/)
-- [ Giving presentation on software project to non-programmers ](https://stephenhaunts.com/2015/10/02/practical-tips-for-talking-at-usergroups-and-conferences-part-1/)
+- [Practical Tips for Talking at Usergroups and Conferences ](https://stephenhaunts.com/2015/10/02/practical-tips-for-talking-at-usergroups-and-conferences-part-1)
+- [ Giving presentation on software project to non-programmers ](https://stephenhaunts.com/2015/10/02/practical-tips-for-talking-at-usergroups-and-conferences-part-1)
 
 ## Everything in one place
 - [reddit.com/user/ashish2199/m/cs_student_subs](https://www.reddit.com/user/ashish2199/m/cs_student_subs) : a multisubreddit of all subreddits of topics related to computer science and programming.
@@ -272,115 +272,115 @@ When learning CS there are some useful sites you must know to get always informe
 - [Fun Fun Function](https://www.youtube.com/c/mpjmevideos) : A weekly series from Mattias Petter Johansson on an assortment of programming topics, including some not directly related to coding.
 
 ## Good Articles
-- [Expectations of a Junior Developer ](http://blog.thefirehoseproject.com/posts/expectations-of-a-junior-developer/)
-- [The Key To Accelerating Your Coding Skills ](http://blog.thefirehoseproject.com/posts/learn-to-code-and-be-self-reliant/)
-- [A Software Developer’s Reading List ](https://stevewedig.com/2014/02/03/software-developers-reading-list/) : Some good books and links in there.
-- [how-to-break-into-tech-job-hunting-and-interviews/ ](http://haseebq.com/how-to-break-into-tech-job-hunting-and-interviews/)
+- [Expectations of a Junior Developer ](http://blog.thefirehoseproject.com/posts/expectations-of-a-junior-developer)
+- [The Key To Accelerating Your Coding Skills ](http://blog.thefirehoseproject.com/posts/learn-to-code-and-be-self-reliant)
+- [A Software Developer’s Reading List ](https://stevewedig.com/2014/02/03/software-developers-reading-list) : Some good books and links in there.
+- [how-to-break-into-tech-job-hunting-and-interviews/ ](http://haseebq.com/how-to-break-into-tech-job-hunting-and-interviews)
 - [40 Keys Computer Science Concepts Explained In Layman’s Terms ](http://carlcheo.com/compsci)
-- [What every programmer should know about memory, Part 1](https://lwn.net/Articles/250967/)
-- [We are reinventing the retail industry through innovative technology](http://multithreaded.stitchfix.com/)
-- [Unicode ](https://www.joelonsoftware.com/2003/10/08/the-absolute-minimum-every-software-developer-absolutely-positively-must-know-about-unicode-and-character-sets-no-excuses/)
-- [What every programmer absolutely, positively needs to know about encodings and character sets to work with text](http://kunststube.net/encoding/)
+- [What every programmer should know about memory, Part 1](https://lwn.net/Articles/250967)
+- [We are reinventing the retail industry through innovative technology](http://multithreaded.stitchfix.com)
+- [Unicode ](https://www.joelonsoftware.com/2003/10/08/the-absolute-minimum-every-software-developer-absolutely-positively-must-know-about-unicode-and-character-sets-no-excuses)
+- [What every programmer absolutely, positively needs to know about encodings and character sets to work with text](http://kunststube.net/encoding)
 - [List of algorithms](https://www.wikiwand.com/en/List_of_algorithms)
 - [Dive into the byte code](https://www.wikiwand.com/en/Java_bytecode)
-- [What every computer science major should know ](http://matt.might.net/articles/what-cs-majors-should-know/)
-- [Teach Yourself Computer Science](https://teachyourselfcs.com/)
+- [What every computer science major should know ](http://matt.might.net/articles/what-cs-majors-should-know)
+- [Teach Yourself Computer Science](https://teachyourselfcs.com)
 - [Data Structure Map](https://fkcd.ca/b7d.svg)
 - [A Gentle Introduction To Graph Theory ](https://dev.to/vaidehijoshi/a-gentle-introduction-to-graph-theory)
 - [Linux Inside](https://0xax.gitbooks.io/linux-insides/content/Booting/linux-bootstrap-1.html)
-- [A programmer friendly language that compiles to Lua.](http://moonscript.org/)
+- [A programmer friendly language that compiles to Lua.](http://moonscript.org)
 
 ## Podcasts
-- [Coding Blocks - Learning principles, patterns and better practices on the go](http://www.codingblocks.net/)
-- [MS Dev Show](http://msdevshow.com/)
-- [The Cynical Developer](http://cynicaldeveloper.com/)
-- [Herding Code](http://herdingcode.com/)
-- [Code Newbie](http://www.codenewbie.org/)
-- [Software Engineering Radio](http://www.se-radio.net/)
+- [Coding Blocks - Learning principles, patterns and better practices on the go](http://www.codingblocks.net)
+- [MS Dev Show](http://msdevshow.com)
+- [The Cynical Developer](http://cynicaldeveloper.com)
+- [Herding Code](http://herdingcode.com)
+- [Code Newbie](http://www.codenewbie.org)
+- [Software Engineering Radio](http://www.se-radio.net)
 - [JavaScript Jabber](https://devchat.tv/js-jabber)
 - [Developer Tea](https://spec.fm/podcasts/developer-tea) : A podcast for developers designed to fit inside your tea break.
-- [Full Stack Radio](http://www.fullstackradio.com/) : Everything from product design and user experience to unit testing and system administration. 
-- [Software Engineering Daily](https://softwareengineeringdaily.com/) : A daily technical interview about software topics
+- [Full Stack Radio](http://www.fullstackradio.com) : Everything from product design and user experience to unit testing and system administration. 
+- [Software Engineering Daily](https://softwareengineeringdaily.com) : A daily technical interview about software topics
 
 ## Building a Simple Compiler/interpreter
-- [Resources for Amateur Compiler Writers](http://c9x.me/compile/bib/)
+- [Resources for Amateur Compiler Writers](http://c9x.me/compile/bib)
 - [:snowman: Possibly the smallest compiler ever](https://github.com/thejameskyle/the-super-tiny-compiler)
 - [Writing My First Compiler ](https://dev.to/fcpauldiaz/writing-my-first-compiler)
 - [Structure and Interpretation of Computer Programs](https://sarabander.github.io/sicp/html/index.xhtml)
--  [Let’s Build A Simple Interpreter. Part 1. ](https://ruslanspivak.com/lsbasi-part1/)
+-  [Let’s Build A Simple Interpreter. Part 1. ](https://ruslanspivak.com/lsbasi-part1)
 -  [Growing a compiler](http://www.cs.dartmouth.edu/~mckeeman/cs48/mxcom/gem/html/GrowingCompiler.html)
 
 ## Tutorials
-- [Subtle | Poor Man's CI](https://www.subtle.press/course/poor-mans-ci/) : Learn how continuous integration platforms work under the hood, by building one of your own on top of git with Node.js
-- [Tutorialspoint ](http://www.tutorialspoint.com/)
-- [W3Schools Online Web Tutorials ](http://www.w3schools.com/)
-- [Open Data Structures ](http://opendatastructures.org/) : Excellent resource for learning about DS and algos , provides code in various languages C++ , Java , pseudocode
+- [Subtle | Poor Man's CI](https://www.subtle.press/course/poor-mans-ci) : Learn how continuous integration platforms work under the hood, by building one of your own on top of git with Node.js
+- [Tutorialspoint ](http://www.tutorialspoint.com)
+- [W3Schools Online Web Tutorials ](http://www.w3schools.com)
+- [Open Data Structures ](http://opendatastructures.org) : Excellent resource for learning about DS and algos , provides code in various languages C++ , Java , pseudocode
 - [Data Structures and Algorithms by John Morris ](http://oopweb.com/Algorithms/Documents/PLDS210/VolumeFrames.html) : another good source with code and its analysis
-- [CMSI 281: Data Structures ](http://cs.lmu.edu/~ray/classes/dsa/) : light weight introduction to DS
+- [CMSI 281: Data Structures ](http://cs.lmu.edu/~ray/classes/dsa) : light weight introduction to DS
 - [How to Program in C++  ](http://cs.fit.edu/~mmahoney/cse2050/how2cpp.html) : Good resource for revising C++ topics and STL
-- [TopCoder Tutorials ](https://www.topcoder.com/community/data-science/data-science-tutorials/)
-- [A Hacker's Guide to Git ](http://wildlyinaccurate.com/a-hackers-guide-to-git/) : for those wanting to learn git with a solid foundation
+- [TopCoder Tutorials ](https://www.topcoder.com/community/data-science/data-science-tutorials)
+- [A Hacker's Guide to Git ](http://wildlyinaccurate.com/a-hackers-guide-to-git) : for those wanting to learn git with a solid foundation
 - [Git from the inside out ](http://maryrosecook.com/blog/post/git-from-the-inside-out)
 - [Learn UNIX in 10 minutes](http://freeengineer.org/learnUNIXin10minutes.html)
-- [The Bash Guide](http://guide.bash.academy/) : very good guide for learning the Bash Shell
-- [Linux Tutorial ](http://ryanstutorials.net/linuxtutorial/) : good resource for learning Linux
+- [The Bash Guide](http://guide.bash.academy) : very good guide for learning the Bash Shell
+- [Linux Tutorial ](http://ryanstutorials.net/linuxtutorial) : good resource for learning Linux
 - [UNIX Tutorial - Introduction ](http://www.ee.surrey.ac.uk/Teaching/Unix/unixintro.html)
-- [Linux Tutorial for Beginners ](http://www.ee.surrey.ac.uk/Teaching/Unix/)
+- [Linux Tutorial for Beginners ](http://www.ee.surrey.ac.uk/Teaching/Unix)
 - [Learning the shell. ](http://linuxcommand.org/learning_the_shell.php)
 - [Dynamic programming - PrismoSkills](http://prismoskills.appspot.com/lessons/Dynamic_Programming/Chapter_01_-_Introduction.jsp) : very good resource if want to learn how to solve DP problems.
 - [Deep C  ](http://www.slideshare.net/olvemaudal/deep-c) : very good presentation on C language
 - [C programming language Frequently Asked Questions ](http://c-faq.com/index.html)
-- [OS Course Notes ](https://www.cs.uic.edu/~jbell/CourseNotes/OperatingSystems/) : Chapter wise course notes according to Galvin's book
-- [SQL (Structured Query Language) in one page : SQL.SU ](http://www.cheat-sheets.org/sites/sql.su/) : a very good SQL cheat sheet
+- [OS Course Notes ](https://www.cs.uic.edu/~jbell/CourseNotes/OperatingSystems) : Chapter wise course notes according to Galvin's book
+- [SQL (Structured Query Language) in one page : SQL.SU ](http://www.cheat-sheets.org/sites/sql.su) : a very good SQL cheat sheet
 - [Introduction to C Programming ](http://www.le.ac.uk/users/rjm1/cotter/index.htm)
 - [MySQL Essentials ](http://www.techotopia.com/index.php/MySQL_Essentials)
-- [http://www.mysqltutorial.org/ ](http://www.mysqltutorial.org/)
-- [Best Of - Gustavo Duarte  ](http://duartes.org/gustavo/blog/best-of/) : contains articles on various topics
-- [Collecting all the cheat sheets ](http://overapi.com/) : cheat sheets for lots of programming languages
-- [The Descent to C  ](http://www.chiark.greenend.org.uk/~sgtatham/cdescent/) : for those moving to C from some higher programming language like java or python.
+- [http://www.mysqltutorial.org/ ](http://www.mysqltutorial.org)
+- [Best Of - Gustavo Duarte  ](http://duartes.org/gustavo/blog/best-of) : contains articles on various topics
+- [Collecting all the cheat sheets ](http://overapi.com) : cheat sheets for lots of programming languages
+- [The Descent to C  ](http://www.chiark.greenend.org.uk/~sgtatham/cdescent) : for those moving to C from some higher programming language like java or python.
 - [VimTutor+ ](https://vimtutorplus.herokuapp.com/exercise/1) : learn VIM from browser itself
-- [HackerEarth Tutorials ](https://learn.hackerearth.com/tutorials/) : Good resource for DS and Algos tutorial
-- [Linux Journey ](https://linuxjourney.com/) : good site for learning linux
+- [HackerEarth Tutorials ](https://learn.hackerearth.com/tutorials) : Good resource for DS and Algos tutorial
+- [Linux Journey ](https://linuxjourney.com) : good site for learning linux
 - [C Programming ](http://www.cs.cf.ac.uk/Dave/C/CE.html)
 - [CS 2112/ENGRD 2112 Fall 2015 ](http://www.cs.cornell.edu/courses/cs2112/2015fa/lectures/index.html) : Good notes on data structures and algorithms.
-- [More about Github-flavored markdown](https://guides.github.com/features/mastering-markdown/)
+- [More about Github-flavored markdown](https://guides.github.com/features/mastering-markdown)
 - [The Unix Programming Environment](http://product.half.ebay.com/The-UNIX-Programming-Environment-by-Brian-W-Kernighan-and-Rob-Pike-1983-Other/54385&tg=info)
-- [The Linux Command Line: A Complete Introduction](https://www.amazon.com/dp/1593273894/)
+- [The Linux Command Line: A Complete Introduction](https://www.amazon.com/dp/1593273894)
 - [TCP/IP Illustrated Series](https://en.wikipedia.org/wiki/TCP/IP_Illustrated)
-- [Head First Design Patterns](https://www.amazon.com/gp/product/0596007124/)
+- [Head First Design Patterns](https://www.amazon.com/gp/product/0596007124)
 - [Design Patterns: Elements of Reusable Object-Oriented Software](https://www.amazon.com/Design-Patterns-Elements-Reusable-Object-Oriented/dp/0201633612) : aka the "Gang Of Four" book, or GOF
-- [UNIX and Linux System Administration Handbook, 4th Edition](https://www.amazon.com/UNIX-Linux-System-Administration-Handbook/dp/0131480057/)
-- [Programming, Web Development, and DevOps news, tutorials and tools for beginners to experts](https://dzone.com/)
+- [UNIX and Linux System Administration Handbook, 4th Edition](https://www.amazon.com/UNIX-Linux-System-Administration-Handbook/dp/0131480057)
+- [Programming, Web Development, and DevOps news, tutorials and tools for beginners to experts](https://dzone.com)
 
 
 ## Watch others code
-- [LiveEdu.tv](https://www.liveedu.tv/) : screencast of people building application, websites, games, ect.
+- [LiveEdu.tv](https://www.liveedu.tv) : screencast of people building application, websites, games, ect.
 
 ## What should a programmer know
-- [Programmer Competency Matrix  ](http://sijinjoseph.com/programmer-competency-matrix/) : article for knowing what our level as a programmer is.
-- [GitHub.com Build software better, together  ](https://github.com/) : Place to showcase your project and collaborate with others. (Must know Git in order to use it effectively)
+- [Programmer Competency Matrix  ](http://sijinjoseph.com/programmer-competency-matrix) : article for knowing what our level as a programmer is.
+- [GitHub.com Build software better, together  ](https://github.com) : Place to showcase your project and collaborate with others. (Must know Git in order to use it effectively)
 - [Gitlab offers free unlimited (private) repositories and unlimited collaborators](https://gitlab.com).
 
 ## Competitive programming
-- [WakaTime](https://wakatime.com/) : leaderboards of coding metrics collected via editor plugins
-- [HackerRank ](http://hackerrank.com/)
-- [Codeforces ](http://codeforces.com/)
-- [topcoder ](http://topcoder.com/)
+- [WakaTime](https://wakatime.com) : leaderboards of coding metrics collected via editor plugins
+- [HackerRank ](http://hackerrank.com)
+- [Codeforces ](http://codeforces.com)
+- [topcoder ](http://topcoder.com)
 - [UVa Online Judge ](https://uva.onlinejudge.org) : hundreds of problems supporting multiple languages.
-- [HackerEarth - Programming challenges and Developer jobs ](http://hackerearth.com/)
-- [CodeChef ](http://codechef.com/)
+- [HackerEarth - Programming challenges and Developer jobs ](http://hackerearth.com)
+- [CodeChef ](http://codechef.com)
 - [PKU ACM ICPC Practice problems ](http://poj.org/problemlist)
 - [Archived Problems - Project Euler ](https://projecteuler.net/archives)
 - [Google Code Jam Practice and ](https://code.google.com/codejam/contests.html) : past contest problems for practice
-- [Sphere Online Judge (SPOJ) ](http://www.spoj.com/)
-- [Art of Problem Solving](https://artofproblemsolving.com/)
+- [Sphere Online Judge (SPOJ) ](http://www.spoj.com)
+- [Art of Problem Solving](https://artofproblemsolving.com)
 - [Riddles.io AI Games](https://www.riddles.io) : Compete with your bot and dominate the leaderboards!
 - [Codingame](https://www.codingame.com) : Learn coding through games and challenges!
-- [Codewars](https://www.codewars.com/) : Rank up by completing code kata
-- [Codefights](https://codefights.com/) : Test your coding skills
+- [Codewars](https://www.codewars.com) : Rank up by completing code kata
+- [Codefights](https://codefights.com) : Test your coding skills
 
 ## Computer Books
-- [IT eBooks - Free Download - Big Library  ](http://it-ebooks.info/) : website for downloading ebooks without any advertisement and instant downloads.
+- [IT eBooks - Free Download - Big Library  ](http://it-ebooks.info) : website for downloading ebooks without any advertisement and instant downloads.
 - [github.com/vhf/free-programming-books ](https://github.com/vhf/free-programming-books/blob/master/free-programming-books.md) : More than 500 free ebooks on almost any language you can think of
 - [Computer Science Books Online ](http://www.sciencebooksonline.info/computer-science.html) : about 150 computer free ebooks
 - [Best books for GATE CSE ](http://gatecse.in/wiki/Best_books_for_CSE#Best_Books_for_GATE_in_CSE)
@@ -394,7 +394,7 @@ When learning CS there are some useful sites you must know to get always informe
 - [mycodeschool ](https://www.youtube.com/user/mycodeschool/videos) : Data structures and algorithms tutorials
 - [CodeGeek ](https://www.youtube.com/channel/UCJYhP1lceSUc1bg0LRBUvqA/videos)
 - [CodingMadeEasy  ](https://www.youtube.com/user/CodingMadeEasy/videos) : C++ tutorials
-- [XDA-University - Helping You Learn Android Development ](http://xda-university.com/)
+- [XDA-University - Helping You Learn Android Development ](http://xda-university.com)
 - [DevTips ](https://www.youtube.com/user/DevTipsForDesigners/videos) : web dev tutorials
 - [codedamn  ](https://www.youtube.com/channel/UCJUmE61LxhbhudzUugHL2wQ/videos) : front end web dev tutorials
 - [Design and Analysis of Algorithms ](http://openclassroom.stanford.edu/MainFolder/CoursePage.php?course=IntroToAlgorithms)
@@ -403,55 +403,55 @@ When learning CS there are some useful sites you must know to get always informe
 - [Kathryn Hodge ](https://www.youtube.com/channel/UC4DwZ2VXM2KWtzHjVk9M_xg/videos) : Has good videos for beginners
 
 ## Online Compiler and Sharing Code snippets
-- [CodePad](https://codepad.remoteinterview.io/) : Code editor to try, test and run 25+ languages
-- [JSFiddle](https://jsfiddle.net/) : Test your JavaScript, CSS, HTML or CoffeeScript with online code editor
-- [Ideone.com ](https://ideone.com/)
-- [Pastebin.com ](http://pastebin.com/)
-- [Godbolt.org ](https://godbolt.org/): Excellent tool for exploring the assembly output of different compilers with and without optimization.
+- [CodePad](https://codepad.remoteinterview.io) : Code editor to try, test and run 25+ languages
+- [JSFiddle](https://jsfiddle.net) : Test your JavaScript, CSS, HTML or CoffeeScript with online code editor
+- [Ideone.com ](https://ideone.com)
+- [Pastebin.com ](http://pastebin.com)
+- [Godbolt.org ](https://godbolt.org): Excellent tool for exploring the assembly output of different compilers with and without optimization.
 
 ## Blogs of Developers
-- [Coding Horror](http://blog.codinghorror.com/) : one the best coding blog
-- [WildMl](http://www.wildml.com/) : A blog for machine learning.
-- [Armin Ronacher's Thoughts and Writings](http://lucumr.pocoo.org/) : blog on Python and open source
-- [Eli Bendersky](http://eli.thegreenplace.net/) : everything from Python to LLVM
-- [Joel on Software](http://joelonsoftware.com/)
-- [ Stephen Haunts { Coding in the Trenches } ](https://stephenhaunts.com/)
-- [Programming in the 21st Century](http://prog21.dadgum.com/)
-- [Clean Coder Blog  ](http://blog.cleancoder.com/) : blog of author of book "Clean Code"
-- [Programming Blog](http://www.yegor256.com/) : programming blog of Yegor Bugayenko
+- [Coding Horror](http://blog.codinghorror.com) : one the best coding blog
+- [WildMl](http://www.wildml.com) : A blog for machine learning.
+- [Armin Ronacher's Thoughts and Writings](http://lucumr.pocoo.org) : blog on Python and open source
+- [Eli Bendersky](http://eli.thegreenplace.net) : everything from Python to LLVM
+- [Joel on Software](http://joelonsoftware.com)
+- [ Stephen Haunts { Coding in the Trenches } ](https://stephenhaunts.com)
+- [Programming in the 21st Century](http://prog21.dadgum.com)
+- [Clean Coder Blog  ](http://blog.cleancoder.com) : blog of author of book "Clean Code"
+- [Programming Blog](http://www.yegor256.com) : programming blog of Yegor Bugayenko
 - [CodeAhoy](https://codeahoy.com) : Blog on software and human factors. 100% Tested on Humans.
-- [http://stevehanov.ca/blog/ ](http://stevehanov.ca/blog/)
-- [Geek Land ](https://avidullu.wordpress.com/)
-- [Late Developer ](https://latedev.wordpress.com/)
-- [IT Enthusiast ](http://rodiongork.tumblr.com/)
-- [blog.might.net ](http://matt.might.net/articles/)
-- [CSE Blog - quant, math, computer science puzzles ](http://www.cseblog.com/)
+- [http://stevehanov.ca/blog/ ](http://stevehanov.ca/blog)
+- [Geek Land ](https://avidullu.wordpress.com)
+- [Late Developer ](https://latedev.wordpress.com)
+- [IT Enthusiast ](http://rodiongork.tumblr.com)
+- [blog.might.net ](http://matt.might.net/articles)
+- [CSE Blog - quant, math, computer science puzzles ](http://www.cseblog.com)
 - [Small Programming Challenges and Puzzles](https://www.nayuki.io/category/programming)
-- [My Tech Interviews ](http://www.mytechinterviews.com/)
-- [HackerEarth Blog ](http://blog.hackerearth.com/)
-- [Algo-Geeks ](http://algo-geeks.blogspot.in/)
-- [CoderGears Blog Insights from ](http://www.codergears.com/Blog/) : the CoderGears Team
-- [Runhe Tian Coding Practice ](https://tianrunhe.wordpress.com/)
+- [My Tech Interviews ](http://www.mytechinterviews.com)
+- [HackerEarth Blog ](http://blog.hackerearth.com)
+- [Algo-Geeks ](http://algo-geeks.blogspot.in)
+- [CoderGears Blog Insights from ](http://www.codergears.com/Blog) : the CoderGears Team
+- [Runhe Tian Coding Practice ](https://tianrunhe.wordpress.com)
 - [Paul Graham Essays ](http://www.paulgraham.com/articles.html)
-- [Dan Dreams of Coding ](http://dandreamsofcoding.com/)
-- [Antonio081014's Algorithms Codes ](http://code.antonio081014.com/)
-- [Math ∩ Programming](http://jeremykun.com/)
-- [Takipi Blog ](http://blog.takipi.com/) : mainly focuses on Java and JVM languages
-- [Coding Geek - A blog about IT, programming and Java ](http://coding-geek.com/)
-- [Daedtech.com ](http://www.daedtech.com/) : Stories about software
+- [Dan Dreams of Coding ](http://dandreamsofcoding.com)
+- [Antonio081014's Algorithms Codes ](http://code.antonio081014.com)
+- [Math ∩ Programming](http://jeremykun.com)
+- [Takipi Blog ](http://blog.takipi.com) : mainly focuses on Java and JVM languages
+- [Coding Geek - A blog about IT, programming and Java ](http://coding-geek.com)
+- [Daedtech.com ](http://www.daedtech.com) : Stories about software
 - [Archives — Ask a Manager ](http://www.askamanager.org/archives) : HR related stuff
 
 ## For improving your English
-- [Quia - English ](https://www.quia.com/shared/english/)
+- [Quia - English ](https://www.quia.com/shared/english)
 - [Punctuation and Capitalization Rules](http://www.grammarbook.com/english_rules.asp)
-- [Guide to Grammar and Writing](http://grammar.ccc.commnet.edu/grammar/)
-- [Purdue University Online Writing Lab (OWL) ](https://owl.english.purdue.edu/)
+- [Guide to Grammar and Writing](http://grammar.ccc.commnet.edu/grammar)
+- [Purdue University Online Writing Lab (OWL) ](https://owl.english.purdue.edu)
 - [Englishclub.com/learn-english](https://www.englishclub.com/learn-english.htm)
 
 ## When you get bored from CS related stuff
 
-- [r/ProgrammerHumor](https://www.reddit.com/r/ProgrammerHumor/) : Subreddit dedicated to exactly what it sounds like
-- [Guide to Grammar and Writing](http://grammar.ccc.commnet.edu/grammar/) for those who want to improve their english language skills
+- [r/ProgrammerHumor](https://www.reddit.com/r/ProgrammerHumor) : Subreddit dedicated to exactly what it sounds like
+- [Guide to Grammar and Writing](http://grammar.ccc.commnet.edu/grammar) for those who want to improve their english language skills
 - [Vsauce ](https://www.youtube.com/user/Vsauce/videos) : The best youtube channel
 - [TED ](https://www.youtube.com/user/TEDtalksDirector/videos) : Great talks about technology, entertainment, and design
 - [CrashCourse ](https://www.youtube.com/user/crashcourse/videos) : small courses on various subjects
@@ -463,6 +463,6 @@ When learning CS there are some useful sites you must know to get always informe
 - [Big Think](https://www.youtube.com/user/bigthink/videos) : Expert driven, actionable, educational content, featuring experts ranging from Bill Clinton to Bill Nye
 - [Every Frame a Painting ](https://www.youtube.com/user/everyframeapainting/videos) : High quality analysis of films and filmmaking
 - [TestTube News](https://www.youtube.com/user/TestTubeNetwork/videos) : Interesting information about news from around the world
-- [Reddit the front page of the internet](http://reddit.com/) : Where free time goes to die
+- [Reddit the front page of the internet](http://reddit.com) : Where free time goes to die
 
   ___Maintained with :heart: by sdmg15 & al___

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ When learning CS there are some useful sites you must know to get always informe
 
 ## Coding practice for beginners
 - [freeCodeCamp](https://www.freecodecamp.com) : Learn to code and build projects for nonprofits. Build your full stack web development portfolio today
-- [Reddit.com/r/dailyprogrammer](https://www.reddit.com/r/dailyprogrammer) : interesting programming challenges where you can learn from looking at other's code , even if you are not able to solve code you can look at how others solved.
+- [Reddit.com/r/dailyprogrammer](https://www.reddit.com/r/dailyprogrammer/) : interesting programming challenges where you can learn from looking at other's code , even if you are not able to solve code you can look at how others solved.
 - [Programming by Doing](http://programmingbydoing.com) : very good site for those who want to start with absolute basics
 - [CodeAbbey - a place where everyone can master programming](http://www.codeabbey.com) : Best place to begin with problems that start at the easiest and gradually increase difficulty with each problem.
 - [Exercism.io](http://exercism.io) : download and solve practice problems in over 30 different languages, and share your solution with others.
@@ -71,21 +71,21 @@ When learning CS there are some useful sites you must know to get always informe
 - [Codeacademy](https://www.codecademy.com) : Learn to code interactively, for free.
 
 ## For those who want to start a small project but can't find the ideas
-- [martyr2s-mega-project-ideas-list](http://www.dreamincode.net/forums/topic/78802-martyr2s-mega-project-ideas-list) : contains about 125 project ideas from beginner to intermediate level.
+- [martyr2s-mega-project-ideas-list](http://www.dreamincode.net/forums/topic/78802-martyr2s-mega-project-ideas-list/) : contains about 125 project ideas from beginner to intermediate level.
 - [karan/Projects](https://github.com/karan/Projects) : a large collection of small projects for beginners with
 - [Wrong "big projects" for beginners](http://rodiongork.tumblr.com/post/108155476418/wrong-big-projects-for-beginners) : How to choose where to start
 - [vicky002/1000-Projects](https://github.com/vicky002/1000_Projects) : Mega List of practical projects that one can solve in any programming language!
 
 ## General Coding advice
-- [Things I Wish Someone Had Told Me When I Was Learning How to Code — Free Code Camp](https://medium.com/m/global-identity?redirectUrl=https://medium.freecodecamp.com/things-i-wish-someone-had-told-me-when-i-was-learning-how-to-code-565fc9dcb329)
+- [Things I Wish Someone Had Told Me When I Was Learning How to Code — Free Code Camp](https://medium.freecodecamp.com/things-i-wish-someone-had-told-me-when-i-was-learning-how-to-code-565fc9dcb329?gi=463de842ab80)
 - [Lessons From A Lifetime Of Being A Programmer](http://thecodist.com/article/lessons_from_a_lifetime_of_being_a_programmer)
 - [Principles of Good Programming](http://www.artima.com/weblogs/viewpost.jsp?thread=331531)
 - [What every computer science major should know](http://matt.might.net/articles/what-cs-majors-should-know)
-- [How to become a programmer, or the art of Googling well](https://okepi.wordpress.com/2014/08/21/how-to-become-a-programmer-or-the-art-of-googling-well)
-- [Code Review Best Practices](http://www.kevinlondon.com/2015/05/05/code-review-best-practices.html)
-- [Dieter Rams : 10 Principles of Good Product Design](https://stephenhaunts.com/2013/12/11/dieter-rams-10-principles-of-good-product-design)
+- [How to become a programmer, or the art of Googling well](https://okepi.wordpress.com/2014/08/21/how-to-become-a-programmer-or-the-art-of-googling-well/)
+- [Code Review Best Practices](https://www.kevinlondon.com/2015/05/05/code-review-best-practices.html)
+- [Dieter Rams : 10 Principles of Good Product Design](https://stephenhaunts.com/2013/12/11/dieter-rams-10-principles-of-good-product-design/)
 - [10-ways-to-be-a-better-developer](https://stephenhaunts.files.wordpress.com/2014/04/10-ways-to-be-a-better-developer.png)
-- [Working as a Software Developer](https://henrikwarne.com/2012/12/12/working-as-a-software-developer)
+- [Working as a Software Developer](https://henrikwarne.com/2012/12/12/working-as-a-software-developer/)
 - [Software design pattern](https://en.wikipedia.org/wiki/Software_design_pattern) : The entire collection of Design Patterns.
 - [Design Patterns](https://sourcemaking.com/design_patterns) : Design Patterns explained in detail with examples.
 
@@ -93,8 +93,8 @@ When learning CS there are some useful sites you must know to get always informe
 - [CS 106B Coding Style Guide](http://stanford.edu/class/archive/cs/cs106b/cs106b.1158/styleguide.shtml) : must see for those who create spaghetti
 - [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html)
 - [Airbnb JS Style Guide](https://github.com/airbnb/javascript) : A mostly reasonable approach to JavaScript
-- [What are some bad coding habits you would recommend a beginner avoid getting into?](https://www.reddit.com/r/learnprogramming/comments/1i4ds4/what_are_some_bad_coding_habits_you_would)
-- [Good C programming habits. • /r/C_Programming](https://www.reddit.com/r/C_Programming/comments/1vuubw/good_c_programming_habits)
+- [What are some bad coding habits you would recommend a beginner avoid getting into?](https://www.reddit.com/r/learnprogramming/comments/1i4ds4/what_are_some_bad_coding_habits_you_would/)
+- [Good C programming habits. • /r/C_Programming](https://www.reddit.com/r/C_Programming/comments/1vuubw/good_c_programming_habits/)
 - [How to Report Bugs Effectively](https://www.chiark.greenend.org.uk/~sgtatham/bugs.html)
 - [Debugging Faqs](http://www.umich.edu/~eecs381/generalFAQ/Debugging.html)
 - [Stuff you need to Code Better!](http://codebetter.com)
@@ -107,62 +107,62 @@ When learning CS there are some useful sites you must know to get always informe
 ### Interview Preparation
 - [GeeksforGeeks | A computer science portal for geeks](http://www.geeksforgeeks.org) : also subscribe to their feeds to get links to their new articles.
 - [A site for technical interview questions, brain teasers, puzzles, quizzles](https://www.techinterview.org) : whatever the heck those are) and other things that make you think!
-- [Problems | LeetCode OJ](https://leetcode.com/problemset/algorithms) : Coding practice for interviews
+- [Problems | LeetCode OJ](https://leetcode.com/problemset/algorithms/) : Coding practice for interviews
 - [Programmer And Software Interview Questions Answers](http://www.programmerinterview.com)
-- [Reddit.com/user/ashish2199/m/puzzles](https://www.reddit.com/user/ashish2199/m/puzzles) : Logic Puzzles
+- [Reddit.com/user/ashish2199/m/puzzles](https://www.reddit.com/user/ashish2199/m/puzzles/) : Logic Puzzles
 - [A Collection of Quant Riddles With Answers](http://puzzles.nigelcoldwell.co.uk)
 - [Aptitude Questions and Answers](http://www.indiabix.com) : Quant and aptitude preparation
-- [Interview Archives - Java Honk](http://javahonk.com/category/interview)
-- [Top 10 Algorithms for Coding Interview](http://www.programcreek.com/2012/11/top-10-algorithms-for-coding-interview)
+- [Interview Archives - Java Honk](http://javahonk.com/category/interview/)
+- [Top 10 Algorithms for Coding Interview](http://www.programcreek.com/2012/11/top-10-algorithms-for-coding-interview/)
 - [Algorithm design canvas](https://www.hiredintech.com/algorithm-design))
 - [Big-O Algorithm Complexity Cheat Sheet](http://bigocheatsheet.com/#)
 - [Unix / Linux Cheat Sheet](http://cheatsheetworld.com/programming/unix-linux-cheat-sheet)
 - [How to interview](http://kelukelu.me/interview/index.html)
 - [How to Ace an Algorithms Interview](http://www.palantir.com/2011/09/how-to-rock-an-algorithms-interview)
-- [Delightful Puzzles](http://gurmeet.net/puzzles)
-- [visualising data structures and algorithms through animation](https://visualgo.net)
-- [Here's How to Prepare for Tech Interviews • /r/cscareerquestions](https://www.reddit.com/r/cscareerquestions/comments/1jov24/heres_how_to_prepare_for_tech_interviews)
+- [Delightful Puzzles](http://gurmeet.net/puzzles/)
+- [visualising data structures and algorithms through animation](https://visualgo.net/en)
+- [Here's How to Prepare for Tech Interviews • /r/cscareerquestions](https://www.reddit.com/r/cscareerquestions/comments/1jov24/heres_how_to_prepare_for_tech_interviews/)
 - [Guide to Tech Interviews](https://www.kchodorow.com/blog/2013/02/28/guide-to-tech-interviews)
-- [Why You Make Less Money • /r/cscareerquestions](https://www.reddit.com/r/cscareerquestions/comments/1b8wa3/why_you_make_less_money)
+- [Why You Make Less Money • /r/cscareerquestions](https://www.reddit.com/r/cscareerquestions/comments/1b8wa3/why_you_make_less_money/)
 - [IIT Delhi Placement Experience](http://placement-iit2013.blogspot.in)
-- [what_are_your_goto_questions_for_the_do_you_have?](https://www.reddit.com/r/cscareerquestions/comments/209rkq/what_are_your_goto_questions_for_the_do_you_have)
-- [/r/cscareerquestions](https://www.reddit.com/r/cscareerquestions/comments/20ahfq/heres_a_pretty_big_list_of_programming_interview) : Here's a pretty big list of programming interview questions I compiled while studying for big 4 interviews. I think you guys will find it useful! •
-- [Interviewing At Jane Street](https://blogs.janestreet.com/interviewing-at-jane-street)
+- [what_are_your_goto_questions_for_the_do_you_have?](https://www.reddit.com/r/cscareerquestions/comments/209rkq/what_are_your_goto_questions_for_the_do_you_have/)
+- [/r/cscareerquestions](https://www.reddit.com/r/cscareerquestions/comments/20ahfq/heres_a_pretty_big_list_of_programming_interview/) : Here's a pretty big list of programming interview questions I compiled while studying for big 4 interviews. I think you guys will find it useful! •
+- [Interviewing At Jane Street](https://blogs.janestreet.com/interviewing-at-jane-street/)
 - [How to prepare for an interview - 1](http://se7so.blogspot.in/2014/01/how-to-prepare-for-interview-1.html)
 - [Summer Internship: The Ultimate Guide](eulercoder.me/blog/career/Summer-Internship-the-ultimate-guide)
 - [The 25 most difficult HR questions](http://www.datsi.fi.upm.es/~frosal/docs/25mdq.html)
 - [Job interviews News, Videos, Reviews and Gossip - Lifehacker](http://lifehacker.com/tag/job-interviews)
 - [How to Answer the Toughest 40 Job Interview Questions | ICS Job Portal](http://www.icsjobportal.com/blog/job-interview-questions)
 - [Job Interview Questions and Best Answers](https://www.thebalance.com/job-interview-questions-and-answers-2061204)
-- [How to Answer "Tell Me a Little About Yourself" | The Art of Manliness](http://www.artofmanliness.com/2016/01/05/tell-me-a-little-about-yourself)
-- [Job Interview: How to Ace a Job Interview | The Art of Manliness](http://www.artofmanliness.com/2012/08/06/how-to-ace-a-job-interview)
-- [Give your résumé a face lift](http://www.lifeclever.com/give-your-resume-a-face-lift)
+- [How to Answer "Tell Me a Little About Yourself" | The Art of Manliness](http://www.artofmanliness.com/2016/01/05/tell-me-a-little-about-yourself/)
+- [Job Interview: How to Ace a Job Interview | The Art of Manliness](http://www.artofmanliness.com/2012/08/06/how-to-ace-a-job-interview/)
+- [Give your résumé a face lift](http://www.lifeclever.com/give-your-resume-a-face-lift/)
 - [BIG O Misconceptions](http://ssp.impulsetrain.com/big-o.html)
 - [Bitwise tricks](https://gist.github.com/dideler/2365607)
-- [Core Java Interview questions - Interview question on each topic](http://javahonk.com/core-java-interview-questions)
+- [Core Java Interview questions - Interview question on each topic](http://javahonk.com/core-java-interview-questions/)
 - [Java Interview Questions and Answers](https://adnjavainterview.blogspot.in)
-- [Big collection of interview preparation links • /r/cscareerquestions](https://www.reddit.com/r/cscareerquestions/comments/2lzc4h/big_collection_of_interview_preparation_links)
-- [Unsolicited_advice_for_job_seekers_and_employers](https://www.reddit.com/r/india/comments/1clgdj/unsolicited_advice_for_job_seekers_and_employers)
+- [Big collection of interview preparation links • /r/cscareerquestions](https://www.reddit.com/r/cscareerquestions/comments/2lzc4h/big_collection_of_interview_preparation_links/)
+- [Unsolicited_advice_for_job_seekers_and_employers](https://www.reddit.com/r/india/comments/1clgdj/unsolicited_advice_for_job_seekers_and_employers/)
 - [five-essential-phone-screen-questions - steveyegge2](https://sites.google.com/site/steveyegge2/five-essential-phone-screen-questions)
-- [CS9: Problem-Solving for the CS Technical Interview](http://web.stanford.edu/class/cs9)
+- [CS9: Problem-Solving for the CS Technical Interview](http://web.stanford.edu/class/cs9/)
 - [Mission-peace/interview problems](https://github.com/mission-peace/interview/wiki) : A large collection of coding interview problems
 - [SQL Joins explained using venn diagram](http://stevestedman.com/wp-content/uploads/VennDiagram1.pdf)
 - [10 Frequently asked SQL Query Interview Questions](http://www.java67.com/2013/04/10-frequently-asked-sql-query-interview-questions-answers-database.html)
-- [Get Ready to Learn SQL: 8. Database Normalization Explained in Simple English - Essential SQL](http://www.essentialsql.com/get-ready-to-learn-sql-database-normalization-explained-in-simple-english)
+- [Get Ready to Learn SQL: 8. Database Normalization Explained in Simple English - Essential SQL](https://www.essentialsql.com/get-ready-to-learn-sql-database-normalization-explained-in-simple-english)
 - [Programming Language Concepts: Lecture Notes](http://www.cmi.ac.in/~madhavan/courses/pl2006/lecturenotes/lecture-notes/lecture-notes.html) : OOPs concepts and programming language concepts.
 - [We Help Coders Get Hired](https://www.hiredintech.com/app) : website offering courses on system design, interview strategies, soft skills etc
 - [checkcheckzz/system-design-interview](https://github.com/checkcheckzz/system-design-interview)
-- [How to Break Into the Tech Industry - a Guide to Job Hunting and Tech Interviews](http://haseebq.com/how-to-break-into-tech-job-hunting-and-interviews)
+- [How to Break Into the Tech Industry - a Guide to Job Hunting and Tech Interviews](http://haseebq.com/how-to-break-into-tech-job-hunting-and-interviews/)
 - [Freshers Interviews](http://placementsindia.blogspot.in)
 - [C PUZZLES, Some interesting C problems](http://www.gowrikumar.com/c/index.php)
-- [A site for technical interview questions, brain teasers, puzzles, quizzles (whatever the heck those are) and other things that make you think!](http://www.techinterview.org)
+- [A site for technical interview questions, brain teasers, puzzles, quizzles (whatever the heck those are) and other things that make you think!](https://www.techinterview.org)
 - [wu :: riddles(hard)](https://www.ocf.berkeley.edu/~wwu/riddles/hard.shtml) : logic puzzles and riddles
 - [github.com/odino/interviews](https://github.com/odino/interviews) : list of important questions for interview
 - [svozniuk/java-interviews](https://github.com/svozniuk/java-interviews) : Java interview questions
 - [kimberli/interviews](https://github.com/kimberli/interviews) : study sheet for Interview
 - [Determining the big-O runtimes of these different loops?](https://stackoverflow.com/questions/11094330/determining-the-big-o-runtimes-of-these-different-loops) : really good stackoverflow question that covers basics of calculating runtime complexity.
 - [ChiperSoft/InterviewThis](https://github.com/ChiperSoft/InterviewThis) : questions to ask during on a interview to know more about the company.
-- [SQL interview questions](https://www.jitbit.com/news/181-jitbits-sql-interview-questions) : great SQL test
+- [SQL interview questions](https://www.jitbit.com/news/181-jitbits-sql-interview-questions/) : great SQL test
 
 ## Documentaries
 - Machine that Changed the World - a very good documentary about history of computers
@@ -189,13 +189,13 @@ When learning CS there are some useful sites you must know to get always informe
 ## MOOCs for learning something new
 - [Class Central](https://www.class-central.com) : a directory of 100,000+ student reviews of thousands of MOOCs.
 - [NPTEL Vidoes COMP_SCI_ENGG](https://onlinecourses.nptel.ac.in/explorer/search?category=COMP_SCI_ENGG)
-- [Coursera.org](https://coursera.org)
+- [Coursera.org](https://coursera.org/)
 - [edX](https://www.edx.org)
 - [MOOC.fi](http://mooc.fi/english.html) : Free online courses from the University of Helsinki
 - [Udacity](https://www.udacity.com)
 - [Kadenze | Creative Programming](https://www.kadenze.com/courses?subjects%5B%5D=7): Programming courses focused on art and creativity
 - [UCBerkeley](https://www.youtube.com/user/UCBerkeley/videos)
-- [MIT OCW Electrical Engineering and Computer Science](https://ocw.mit.edu/courses/electrical-engineering-and-computer-science)
+- [MIT OCW Electrical Engineering and Computer Science](https://ocw.mit.edu/courses/electrical-engineering-and-computer-science/)
 - [CS50](https://www.youtube.com/user/cs50tv/videos)
 - [prakhar1989/awesome-CS-courses](https://github.com/prakhar1989/awesome-courses/blob/master/README.md) : List containing large amount of CS courses
 - [Computer Science Resources](https://docs.google.com/spreadsheets/d/1BD8BJJUNaX63m2QmySWMGDp71nx4W4MyyiIBlfMoN3Q/htmlview?sle=true#) : list of MOOCs for autodidacts
@@ -203,16 +203,16 @@ When learning CS there are some useful sites you must know to get always informe
 
 ## Sites related to your preferred programming language (For me Java)
 - [Java Revisited](http://javarevisited.blogspot.in) : good for learning about Java Language and interview preparation.
-- [The Java™ Tutorials](https://docs.oracle.com/javase/tutorial): The best tutorials for Java.
+- [The Java™ Tutorials](https://docs.oracle.com/javase/tutorial/): The best tutorials for Java.
 - [Java Corner at Artima.com](http://www.artima.com/java/index.html)
-- [Java Visualizer](http://www.cs.princeton.edu/~cos126/java_visualize) : helps visualize references , values of variables ect
-- [Java Lecture Notes](http://www.cafeaulait.org/course)
+- [Java Visualizer](http://www.cs.princeton.edu/~cos126/java_visualize/) : helps visualize references , values of variables ect
+- [Java Lecture Notes](http://www.cafeaulait.org/course/)
 - [Learning Java](http://chimera.labs.oreilly.com/books/1234000001805/index.html) : a free online textbook for learning Java
 - [Free Online Chapters of Inside the Java Virtual Machine by Bill Venners](http://www.artima.com/insidejvm/ed2/index.html)
 - [Understanding JVM Internals](http://www.cubrid.org/blog/understanding-jvm-internals)
-- [How Garbage Collection Works](https://www.dynatrace.com/resources/ebooks/javabook/how-garbage-collection-works)
+- [How Garbage Collection Works](https://www.dynatrace.com/resources/ebooks/javabook/how-garbage-collection-works/)
 - [Welcome to JavaWorld.com](http://www.javaworld.com)
-- [The Java Memory Model](http://www.cs.umd.edu/~pugh/java/memoryModel)
+- [The Java Memory Model](http://www.cs.umd.edu/~pugh/java/memoryModel/)
 - [Netbeans Keyboard Shortcuts](https://netbeans.org/project_downloads/usersguide/shortcuts-80.pdf) : Keyboard shortcuts to enhance your productivity when working in Netbeans.
 - [XyzWs Java FAQs](http://www.xyzws.com/javafaq/page/1) : large collection of java interview questions
 - [Search Open Source Java API](http://www.docjar.com) : view source of java library and learn how things are implemented.
@@ -232,18 +232,18 @@ When learning CS there are some useful sites you must know to get always informe
 
 
 ## Learn AI
-- [Unsupervised Sentiment Neuron](https://blog.openai.com/unsupervised-sentiment-neuron)
-- [Robots that learn](https://blog.openai.com/robots-that-learn)
+- [Unsupervised Sentiment Neuron](https://blog.openai.com/unsupervised-sentiment-neuron/)
+- [Robots that learn](https://blog.openai.com/robots-that-learn/)
 - [grakn.ai](https://grakn.ai)
 
 ## Seminar , research writing , talks etc
 - [Advice on Research and Writing](http://www.cs.cmu.edu/~mleone/how-to.html)
 - [Seminar and reports](https://www.cse.iitb.ac.in/~ranade/communicationskills.html)
 - [PHD MS Articles](http://www.cse.iitd.ac.in/~srsarangi/articles.html)
-- [Practical Tips for Talking at Usergroups and Conferences and Giving presentation on software project to non-programmers](https://stephenhaunts.com/2015/10/02/practical-tips-for-talking-at-usergroups-and-conferences-part-1)
+- [Practical Tips for Talking at Usergroups and Conferences and Giving presentation on software project to non-programmers](https://stephenhaunts.com/2015/10/02/practical-tips-for-talking-at-usergroups-and-conferences-part-1/)
 
 ## Everything in one place
-- [reddit.com/user/ashish2199/m/cs_student_subs](https://www.reddit.com/user/ashish2199/m/cs_student_subs) : a multisubreddit of all subreddits of topics related to computer science and programming.
+- [reddit.com/user/ashish2199/m/cs_student_subs](https://www.reddit.com/user/ashish2199/m/cs_student_subs/) : a multisubreddit of all subreddits of topics related to computer science and programming.
 
 ## YouTube Channels
 - [Computerphile](https://www.youtube.com/user/Computerphile/videos) : Must watch for every CS student
@@ -269,17 +269,15 @@ When learning CS there are some useful sites you must know to get always informe
 - [Coding Blocks](https://www.youtube.com/user/codingblocks) : Tutorials, how to's, tips and tricks
 - [Fun Fun Function](https://www.youtube.com/c/mpjmevideos) : A weekly series from Mattias Petter Johansson on an assortment of programming topics, including some not directly related to coding.
 
-<!--- [Codely tv](https://www.youtube.com/UC9IKtxn9AIGelnYmwYr0Lxw) : Interviews, tips and tricks-->
-
 ## Good Articles
-- [Expectations of a Junior Developer](http://blog.thefirehoseproject.com/posts/expectations-of-a-junior-developer)
-- [The Key To Accelerating Your Coding Skills](http://blog.thefirehoseproject.com/posts/learn-to-code-and-be-self-reliant)
-- [A Software Developer’s Reading List](https://stevewedig.com/2014/02/03/software-developers-reading-list) : Some good books and links in there.
+- [Expectations of a Junior Developer](http://blog.thefirehoseproject.com/posts/expectations-of-a-junior-developer/)
+- [The Key To Accelerating Your Coding Skills](http://blog.thefirehoseproject.com/posts/learn-to-code-and-be-self-reliant/)
+- [A Software Developer’s Reading List](https://stevewedig.com/2014/02/03/software-developers-reading-list/) : Some good books and links in there.
 - [40 Keys Computer Science Concepts Explained In Layman’s Terms](http://carlcheo.com/compsci)
-- [What every programmer should know about memory, Part 1](https://lwn.net/Articles/250967)
+- [What every programmer should know about memory, Part 1](https://lwn.net/Articles/250967/)
 - [We are reinventing the retail industry through innovative technology](http://multithreaded.stitchfix.com)
-- [Unicode](https://www.joelonsoftware.com/2003/10/08/the-absolute-minimum-every-software-developer-absolutely-positively-must-know-about-unicode-and-character-sets-no-excuses)
-- [What every programmer absolutely, positively needs to know about encodings and character sets to work with text](http://kunststube.net/encoding)
+- [Unicode](https://www.joelonsoftware.com/2003/10/08/the-absolute-minimum-every-software-developer-absolutely-positively-must-know-about-unicode-and-character-sets-no-excuses/)
+- [What every programmer absolutely, positively needs to know about encodings and character sets to work with text](http://kunststube.net/encoding/)
 - [List of algorithms](https://www.wikiwand.com/en/List_of_algorithms)
 - [Dive into the byte code](https://www.wikiwand.com/en/Java_bytecode)
 - [Data Structure Map](https://fkcd.ca/b7d.svg)
@@ -307,11 +305,11 @@ When learning CS there are some useful sites you must know to get always informe
 - [Software Engineering Daily](https://softwareengineeringdaily.com) : A daily technical interview about software topics
 
 ## Building a Simple Compiler/interpreter
-- [Resources for Amateur Compiler Writers](http://c9x.me/compile/bib)
+- [Resources for Amateur Compiler Writers](http://c9x.me/compile/bib/)
 - [:snowman: Possibly the smallest compiler ever](https://github.com/thejameskyle/the-super-tiny-compiler)
 - [Writing My First Compiler](https://dev.to/fcpauldiaz/writing-my-first-compiler)
 - [Structure and Interpretation of Computer Programs](https://sarabander.github.io/sicp/html/index.xhtml)
-- [Let’s Build A Simple Interpreter. Part 1.](https://ruslanspivak.com/lsbasi-part1)
+- [Let’s Build A Simple Interpreter. Part 1.](https://ruslanspivak.com/lsbasi-part1/)
 - [Growing a compiler](http://www.cs.dartmouth.edu/~mckeeman/cs48/mxcom/gem/html/GrowingCompiler.html)
 
 ## Tutorials
@@ -320,14 +318,14 @@ When learning CS there are some useful sites you must know to get always informe
 - [W3Schools Online Web Tutorials](https://www.w3schools.com)
 - [Open Data Structures](http://opendatastructures.org) : Excellent resource for learning about DS and algos , provides code in various languages C++ , Java , pseudocode
 - [Data Structures and Algorithms by John Morris](http://oopweb.com/Algorithms/Documents/PLDS210/VolumeFrames.html) : another good source with code and its analysis
-- [CMSI 281: Data Structures](http://cs.lmu.edu/~ray/classes/dsa) : light weight introduction to DS
+- [CMSI 281: Data Structures](http://cs.lmu.edu/~ray/classes/dsa/) : light weight introduction to DS
 - [How to Program in C++](http://cs.fit.edu/~mmahoney/cse2050/how2cpp.html) : Good resource for revising C++ topics and STL
-- [TopCoder Tutorials](https://www.topcoder.com/community/data-science/data-science-tutorials)
-- [A Hacker's Guide to Git](https://wildlyinaccurate.com/a-hackers-guide-to-git) : for those wanting to learn git with a solid foundation
+- [TopCoder Tutorials](https://www.topcoder.com/community/data-science/data-science-tutorials/)
+- [A Hacker's Guide to Git](http://wildlyinaccurate.com/a-hackers-guide-to-git) : for those wanting to learn git with a solid foundation
 - [Git from the inside out](https://maryrosecook.com/blog/post/git-from-the-inside-out)
 - [Learn UNIX in 10 minutes](http://freeengineer.org/learnUNIXin10minutes.html)
 - [The Bash Guide](http://guide.bash.academy) : very good guide for learning the Bash Shell
-- [Linux Tutorial](http://ryanstutorials.net/linuxtutorial) : good resource for learning Linux
+- [Linux Tutorial](http://ryanstutorials.net/linuxtutorial/) : good resource for learning Linux
 - [UNIX Tutorial - Introduction](http://www.ee.surrey.ac.uk/Teaching/Unix/unixintro.html)
 - [Linux Tutorial for Beginners](http://www.ee.surrey.ac.uk/Teaching/Unix)
 - [Learning the shell.](http://linuxcommand.org/learning_the_shell.php)
@@ -345,9 +343,9 @@ When learning CS there are some useful sites you must know to get always informe
 - [VimTutor+](https://vimtutorplus.herokuapp.com/exercise/1) : learn VIM from browser itself
 - [HackerEarth Tutorials](https://learn.hackerearth.com/tutorials) : Good resource for DS and Algos tutorial
 - [Linux Journey](https://linuxjourney.com) : good site for learning linux
-- [C Programming](http://users.cs.cf.ac.uk/dave/C/CE.html)
+- [C Programming](http://users.cs.cf.ac.uk/Dave.Marshall/C/CE.html)
 - [CS 2112/ENGRD 2112 Fall 2015](http://www.cs.cornell.edu/courses/cs2112/2015fa/lectures/index.html) : Good notes on data structures and algorithms.
-- [More about Github-flavored markdown](https://guides.github.com/features/mastering-markdown)
+- [More about Github-flavored markdown](https://guides.github.com/features/mastering-markdown/)
 - [The Unix Programming Environment](http://product.half.ebay.com/The-UNIX-Programming-Environment-by-Brian-W-Kernighan-and-Rob-Pike-1983-Other/54385&tg=info)
 - [The Linux Command Line: A Complete Introduction](https://www.amazon.com/Linux-Command-Line-Complete-Introduction/dp/1593273894)
 - [TCP/IP Illustrated Series](https://en.wikipedia.org/wiki/TCP/IP_Illustrated)
@@ -369,10 +367,10 @@ When learning CS there are some useful sites you must know to get always informe
 - [WakaTime](https://wakatime.com) : leaderboards of coding metrics collected via editor plugins
 - [HackerRank](https://www.hackerrank.com)
 - [Codeforces](http://codeforces.com)
-- [topcoder](http://www.topcoder.com)
+- [topcoder](http://www.topcoder.com/)
 - [UVa Online Judge](https://uva.onlinejudge.org) : hundreds of problems supporting multiple languages.
 - [HackerEarth - Programming challenges and Developer jobs](https://www.hackerearth.com)
-- [CodeChef](http://www.codechef.com)
+- [CodeChef](http://www.codechef.com/)
 - [PKU ACM ICPC Practice problems](http://poj.org/problemlist)
 - [Archived Problems - Project Euler](https://projecteuler.net/archives)
 - [Google Code Jam Practice and](https://code.google.com/codejam/past-contests) : past contest problems for practice
@@ -387,7 +385,7 @@ When learning CS there are some useful sites you must know to get always informe
 - [IT eBooks - Free Download - Big Library](http://it-ebooks.info) : website for downloading ebooks without any advertisement and instant downloads.
 - [github.com/vhf/free-programming-books](https://github.com/EbookFoundation/free-programming-books/blob/master/free-programming-books.md) : More than 500 free ebooks on almost any language you can think of
 - [Computer Science Books Online](http://www.sciencebooksonline.info/computer-science.html) : about 150 computer free ebooks
-- [Best books for GATE CSE](http://www.gatecse.in/best-books-for-gate)
+- [Best books for GATE CSE](http://www.gatecse.in/best-books-for-gate/)
 - [cses.fi/book.html](https://cses.fi/book.html)
 - [Library Genesis](http://gen.lib.rus.ec) : Almost any ebook you can think of, including countless CS texts and manuals.
 
@@ -418,13 +416,13 @@ When learning CS there are some useful sites you must know to get always informe
 - [WildMl](http://www.wildml.com) : A blog for machine learning.
 - [Armin Ronacher's Thoughts and Writings](http://lucumr.pocoo.org) : blog on Python and open source
 - [Eli Bendersky](http://eli.thegreenplace.net) : everything from Python to LLVM
-- [Joel on Software](http://www.joelonsoftware.com)
+- [Joel on Software](http://www.joelonsoftware.com/)
 - [Stephen Haunts { Coding in the Trenches }](https://stephenhaunts.com)
 - [Programming in the 21st Century](http://prog21.dadgum.com)
 - [Clean Coder Blog](http://blog.cleancoder.com) : blog of author of book "Clean Code"
 - [Programming Blog](http://www.yegor256.com) : programming blog of Yegor Bugayenko
 - [CodeAhoy](https://codeahoy.com) : Blog on software and human factors. 100% Tested on Humans.
-- [http://stevehanov.ca/blog/](http://stevehanov.ca/blog)
+- [http://stevehanov.ca/blog/](http://stevehanov.ca/blog/)
 - [Geek Land](https://avidullu.wordpress.com)
 - [Late Developer](https://latedev.wordpress.com)
 - [IT Enthusiast](http://rodiongork.tumblr.com)
@@ -434,7 +432,7 @@ When learning CS there are some useful sites you must know to get always informe
 - [My Tech Interviews](http://www.mytechinterviews.com)
 - [HackerEarth Blog](http://blog.hackerearth.com)
 - [Algo-Geeks](http://algo-geeks.blogspot.in)
-- [CoderGears Blog Insights from](http://www.codergears.com/Blog) : the CoderGears Team
+- [CoderGears Blog Insights from](http://www.codergears.com/Blog/) : the CoderGears Team
 - [Runhe Tian Coding Practice](https://tianrunhe.wordpress.com)
 - [Paul Graham Essays](http://www.paulgraham.com/articles.html)
 - [Dan Dreams of Coding](https://dandreamsofcoding.com)
@@ -446,15 +444,15 @@ When learning CS there are some useful sites you must know to get always informe
 - [Archives — Ask a Manager](http://www.askamanager.org/archives) : HR related stuff
 
 ## For improving your English
-- [Quia - English](https://www.quia.com/shared/english)
+- [Quia - English](https://www.quia.com/shared/english/)
 - [Punctuation and Capitalization Rules](http://www.grammarbook.com/english_rules.asp)
-- [Guide to Grammar and Writing](http://grammar.ccc.commnet.edu/grammar) : for those who want to improve their english language skills
+- [Guide to Grammar and Writing](http://grammar.ccc.commnet.edu/grammar/) : for those who want to improve their english language skills
 - [Purdue University Online Writing Lab (OWL)](https://owl.english.purdue.edu)
 - [Englishclub.com/learn-english](https://www.englishclub.com/learn-english.htm)
 
 ## When you get bored from CS related stuff
 
-- [r/ProgrammerHumor](https://www.reddit.com/r/ProgrammerHumor) : Subreddit dedicated to exactly what it sounds like
+- [r/ProgrammerHumor](https://www.reddit.com/r/ProgrammerHumor/) : Subreddit dedicated to exactly what it sounds like
 - [Vsauce](https://www.youtube.com/user/Vsauce/videos) : The best youtube channel
 - [TED](https://www.youtube.com/user/TEDtalksDirector/videos) : Great talks about technology, entertainment, and design
 - [CrashCourse](https://www.youtube.com/user/crashcourse/videos) : small courses on various subjects

--- a/README.md
+++ b/README.md
@@ -465,4 +465,4 @@ When learning CS there are some useful sites you must know to get always informe
 - [TestTube News](https://www.youtube.com/user/TestTubeNetwork/videos) : Interesting information about news from around the world
 - [Reddit the front page of the internet](http://reddit.com) : Where free time goes to die
 
-  ___Maintained with :heart: by sdmg15 & al___
+  **Maintained with :heart: by sdmg15 & al**

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ When learning CS there are some useful sites you must know to get always informe
 - [C PUZZLES, Some interesting C problems](http://www.gowrikumar.com/c/index.php)
 - [A site for technical interview questions, brain teasers, puzzles, quizzles (whatever the heck those are) and other things that make you think!](http://www.techinterview.org)
 - [wu :: riddles(hard)](https://www.ocf.berkeley.edu/~wwu/riddles/hard.shtml) : logic puzzles and riddles
-- [https://github.com/odino/interviews](https://github.com/odino/interviews) : list of important questions for interview
+- [github.com/odino/interviews](https://github.com/odino/interviews) : list of important questions for interview
 - [svozniuk/java-interviews](https://github.com/svozniuk/java-interviews) : Java interview questions
 - [kimberli/interviews](https://github.com/kimberli/interviews) : study sheet for Interview
 - [Determining the big-O runtimes of these different loops?](https://stackoverflow.com/questions/11094330/determining-the-big-o-runtimes-of-these-different-loops) : really good stackoverflow question that covers basics of calculating runtime complexity.
@@ -199,7 +199,9 @@ When learning CS there are some useful sites you must know to get always informe
 - [CS50](https://www.youtube.com/user/cs50tv/videos)
 - [prakhar1989/awesome-CS-courses](https://github.com/prakhar1989/awesome-courses/blob/master/README.md) : List containing large amount of CS courses
 - [Computer Science Resources](https://docs.google.com/spreadsheets/d/1BD8BJJUNaX63m2QmySWMGDp71nx4W4MyyiIBlfMoN3Q/htmlview?sle=true#) : list of MOOCs for autodidacts
-- [https://github.com/prakhar1989/awesome-courses/blob/master/README.md](https://github.com/prakhar1989/awesome-courses/blob/master/README.md) : collection of CS courses on Internet
+
+<!--duplicate-->
+<!--- [https://github.com/prakhar1989/awesome-courses/blob/master/README.md](https://github.com/prakhar1989/awesome-courses/blob/master/README.md) : collection of CS courses on Internet-->
 
 ## Sites related to your preferred programming language (For me Java)
 - [Java Revisited](http://javarevisited.blogspot.in) : good for learning about Java Language and interview preparation.
@@ -240,8 +242,7 @@ When learning CS there are some useful sites you must know to get always informe
 - [Advice on Research and Writing](http://www.cs.cmu.edu/~mleone/how-to.html)
 - [Seminar and reports](https://www.cse.iitb.ac.in/~ranade/communicationskills.html)
 - [PHD MS Articles](http://www.cse.iitd.ac.in/~srsarangi/articles.html)
-- [Practical Tips for Talking at Usergroups and Conferences](https://stephenhaunts.com/2015/10/02/practical-tips-for-talking-at-usergroups-and-conferences-part-1)
-- [Giving presentation on software project to non-programmers](https://stephenhaunts.com/2015/10/02/practical-tips-for-talking-at-usergroups-and-conferences-part-1)
+- [Practical Tips for Talking at Usergroups and Conferences and Giving presentation on software project to non-programmers](https://stephenhaunts.com/2015/10/02/practical-tips-for-talking-at-usergroups-and-conferences-part-1)
 
 ## Everything in one place
 - [reddit.com/user/ashish2199/m/cs_student_subs](https://www.reddit.com/user/ashish2199/m/cs_student_subs) : a multisubreddit of all subreddits of topics related to computer science and programming.
@@ -276,7 +277,6 @@ When learning CS there are some useful sites you must know to get always informe
 - [Expectations of a Junior Developer](http://blog.thefirehoseproject.com/posts/expectations-of-a-junior-developer)
 - [The Key To Accelerating Your Coding Skills](http://blog.thefirehoseproject.com/posts/learn-to-code-and-be-self-reliant)
 - [A Software Developer’s Reading List](https://stevewedig.com/2014/02/03/software-developers-reading-list) : Some good books and links in there.
-- [how-to-break-into-tech-job-hunting-and-interviews/](http://haseebq.com/how-to-break-into-tech-job-hunting-and-interviews)
 - [40 Keys Computer Science Concepts Explained In Layman’s Terms](http://carlcheo.com/compsci)
 - [What every programmer should know about memory, Part 1](https://lwn.net/Articles/250967)
 - [We are reinventing the retail industry through innovative technology](http://multithreaded.stitchfix.com)
@@ -284,12 +284,17 @@ When learning CS there are some useful sites you must know to get always informe
 - [What every programmer absolutely, positively needs to know about encodings and character sets to work with text](http://kunststube.net/encoding)
 - [List of algorithms](https://www.wikiwand.com/en/List_of_algorithms)
 - [Dive into the byte code](https://www.wikiwand.com/en/Java_bytecode)
-- [What every computer science major should know](http://matt.might.net/articles/what-cs-majors-should-know)
-- [Teach Yourself Computer Science](https://teachyourselfcs.com)
 - [Data Structure Map](https://fkcd.ca/b7d.svg)
 - [A Gentle Introduction To Graph Theory](https://dev.to/vaidehijoshi/a-gentle-introduction-to-graph-theory)
 - [Linux Inside](https://0xax.gitbooks.io/linux-insides/content/Booting/linux-bootstrap-1.html)
 - [A programmer friendly language that compiles to Lua.](http://moonscript.org)
+
+<!--duplicate on Interview Documentaries-->
+<!--- [Teach Yourself Computer Science](https://teachyourselfcs.com)-->
+<!--duplicate on general coding advice-->
+<!--- [What every computer science major should know](http://matt.might.net/articles/what-cs-majors-should-know)-->
+<!--duplicate on Interview Preparation-->
+<!--- [how-to-break-into-tech-job-hunting-and-interviews/](http://haseebq.com/how-to-break-into-tech-job-hunting-and-interviews)-->
 
 ## Podcasts
 - [Coding Blocks - Learning principles, patterns and better practices on the go](http://www.codingblocks.net)
@@ -385,7 +390,7 @@ When learning CS there are some useful sites you must know to get always informe
 - [github.com/vhf/free-programming-books](https://github.com/EbookFoundation/free-programming-books/blob/master/free-programming-books.md) : More than 500 free ebooks on almost any language you can think of
 - [Computer Science Books Online](http://www.sciencebooksonline.info/computer-science.html) : about 150 computer free ebooks
 - [Best books for GATE CSE](http://www.gatecse.in/best-books-for-gate)
-- [https://cses.fi/book.html](https://cses.fi/book.html)
+- [cses.fi/book.html](https://cses.fi/book.html)
 - [Library Genesis](http://gen.lib.rus.ec) : Almost any ebook you can think of, including countless CS texts and manuals.
 
 ## Video Tutorials
@@ -445,14 +450,13 @@ When learning CS there are some useful sites you must know to get always informe
 ## For improving your English
 - [Quia - English](https://www.quia.com/shared/english)
 - [Punctuation and Capitalization Rules](http://www.grammarbook.com/english_rules.asp)
-- [Guide to Grammar and Writing](http://grammar.ccc.commnet.edu/grammar)
+- [Guide to Grammar and Writing](http://grammar.ccc.commnet.edu/grammar) : for those who want to improve their english language skills
 - [Purdue University Online Writing Lab (OWL)](https://owl.english.purdue.edu)
 - [Englishclub.com/learn-english](https://www.englishclub.com/learn-english.htm)
 
 ## When you get bored from CS related stuff
 
 - [r/ProgrammerHumor](https://www.reddit.com/r/ProgrammerHumor) : Subreddit dedicated to exactly what it sounds like
-- [Guide to Grammar and Writing](http://grammar.ccc.commnet.edu/grammar) for those who want to improve their english language skills
 - [Vsauce](https://www.youtube.com/user/Vsauce/videos) : The best youtube channel
 - [TED](https://www.youtube.com/user/TEDtalksDirector/videos) : Great talks about technology, entertainment, and design
 - [CrashCourse](https://www.youtube.com/user/crashcourse/videos) : small courses on various subjects
@@ -465,5 +469,8 @@ When learning CS there are some useful sites you must know to get always informe
 - [Every Frame a Painting](https://www.youtube.com/user/everyframeapainting/videos) : High quality analysis of films and filmmaking
 - [TestTube News](https://www.youtube.com/user/TestTubeNetwork/videos) : Interesting information about news from around the world
 - [Reddit the front page of the internet](https://www.reddit.com) : Where free time goes to die
+
+<!--duplicte for improving your english-->
+<!--- [Guide to Grammar and Writing](http://grammar.ccc.commnet.edu/grammar) for those who want to improve their english language skills-->
 
   **Maintained with :heart: by sdmg15 & al**

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ When learning CS there are some useful sites you must know to get always informe
 </ul>
 
 ## When you get stuck
-- [Stack Overflow](http://stackoverflow.com) : subscribe to their weekly newsletter and any other topic which you find interesting
+- [Stack Overflow](https://stackoverflow.com) : subscribe to their weekly newsletter and any other topic which you find interesting
 - [Quora](https://www.quora.com) : A place to share knowledge and better understand the world:
 - [Learn Anything](https://learn-anything.xyz) : Community curated knowledge graph of best paths for learning anything
 
@@ -49,20 +49,20 @@ When learning CS there are some useful sites you must know to get always informe
 - [Hacker News](https://news.ycombinator.com) : news aggregator for programmers where civility is king, try a newsletter to get top news to your inbox:
 - [Hacker Newsletter](http://www.hackernewsletter.com) : curated by hand, delivered weekly
 - [Hacker News Digest](https://hndigest.com) : curated automatically, delivered as frequently as you want
-- [Ars Technica](http://arstechnica.com) : posts unique quality articles
+- [Ars Technica](https://arstechnica.com) : posts unique quality articles
 - [ACM TechNews](http://technews.acm.org)
 - [Lobsters](https://lobste.rs) : Lobsters is a technology-focused community centered around link aggregation and discussion.
-- [TechCrunch](http://techcrunch.com) : another good website for tech news
-- [GSMArena.com](http://gsmarena.com) : news related to latest mobile phones and android.
+- [TechCrunch](https://techcrunch.com) : another good website for tech news
+- [GSMArena.com](http://www.gsmarena.com) : news related to latest mobile phones and android.
 - [product hunt](https://www.producthunt.com) : Discover your next favorite thing
 - [AlternativeTo](https://alternativeto.net) : Crowdsourced software recommendations
 - [Better Dev Links](https://betterdev.link) : Weekly links to help you become a better developer
 
 ## Coding practice for beginners
 - [freeCodeCamp](https://www.freecodecamp.com) : Learn to code and build projects for nonprofits. Build your full stack web development portfolio today
-- [Reddit.com/r/dailyprogrammer](http://www.reddit.com/r/dailyprogrammer) : interesting programming challenges where you can learn from looking at other's code , even if you are not able to solve code you can look at how others solved.
+- [Reddit.com/r/dailyprogrammer](https://www.reddit.com/r/dailyprogrammer) : interesting programming challenges where you can learn from looking at other's code , even if you are not able to solve code you can look at how others solved.
 - [Programming by Doing](http://programmingbydoing.com) : very good site for those who want to start with absolute basics
-- [CodeAbbey - a place where everyone can master programming](http://codeabbey.com) : Best place to begin with problems that start at the easiest and gradually increase difficulty with each problem.
+- [CodeAbbey - a place where everyone can master programming](http://www.codeabbey.com) : Best place to begin with problems that start at the easiest and gradually increase difficulty with each problem.
 - [Exercism.io](http://exercism.io) : download and solve practice problems in over 30 different languages, and share your solution with others.
 - [Programming Tasks](http://rosettacode.org/wiki/Category:Programming_Tasks) : large collection of small programs
 - [karan/Projects-Solutions](https://github.com/karan/Projects-Solutions) Solutions to most of the problems in the link above
@@ -77,12 +77,12 @@ When learning CS there are some useful sites you must know to get always informe
 - [vicky002/1000-Projects](https://github.com/vicky002/1000_Projects) : Mega List of practical projects that one can solve in any programming language!
 
 ## General Coding advice
-- [Things I Wish Someone Had Told Me When I Was Learning How to Code — Free Code Camp](https://medium.freecodecamp.com/things-i-wish-someone-had-told-me-when-i-was-learning-how-to-code-565fc9dcb329#.y5wbd3pj6)
+- [Things I Wish Someone Had Told Me When I Was Learning How to Code — Free Code Camp](https://medium.com/m/global-identity?redirectUrl=https://medium.freecodecamp.com/things-i-wish-someone-had-told-me-when-i-was-learning-how-to-code-565fc9dcb329)
 - [Lessons From A Lifetime Of Being A Programmer](http://thecodist.com/article/lessons_from_a_lifetime_of_being_a_programmer)
 - [Principles of Good Programming](http://www.artima.com/weblogs/viewpost.jsp?thread=331531)
 - [What every computer science major should know](http://matt.might.net/articles/what-cs-majors-should-know)
 - [How to become a programmer, or the art of Googling well](https://okepi.wordpress.com/2014/08/21/how-to-become-a-programmer-or-the-art-of-googling-well)
-- [Code Review Best Practices](http://kevinlondon.com/2015/05/05/code-review-best-practices.html)
+- [Code Review Best Practices](http://www.kevinlondon.com/2015/05/05/code-review-best-practices.html)
 - [Dieter Rams : 10 Principles of Good Product Design](https://stephenhaunts.com/2013/12/11/dieter-rams-10-principles-of-good-product-design)
 - [10-ways-to-be-a-better-developer](https://stephenhaunts.files.wordpress.com/2014/04/10-ways-to-be-a-better-developer.png)
 - [Working as a Software Developer](https://henrikwarne.com/2012/12/12/working-as-a-software-developer)
@@ -95,7 +95,7 @@ When learning CS there are some useful sites you must know to get always informe
 - [Airbnb JS Style Guide](https://github.com/airbnb/javascript) : A mostly reasonable approach to JavaScript
 - [What are some bad coding habits you would recommend a beginner avoid getting into?](https://www.reddit.com/r/learnprogramming/comments/1i4ds4/what_are_some_bad_coding_habits_you_would)
 - [Good C programming habits. • /r/C_Programming](https://www.reddit.com/r/C_Programming/comments/1vuubw/good_c_programming_habits)
-- [How to Report Bugs Effectively](http://www.chiark.greenend.org.uk/~sgtatham/bugs.html)
+- [How to Report Bugs Effectively](https://www.chiark.greenend.org.uk/~sgtatham/bugs.html)
 - [Debugging Faqs](http://www.umich.edu/~eecs381/generalFAQ/Debugging.html)
 - [Stuff you need to Code Better!](http://codebetter.com)
 - [Directory of Online CS Courses](https://github.com/open-source-society/computer-science)
@@ -106,7 +106,7 @@ When learning CS there are some useful sites you must know to get always informe
 
 ### Interview Preparation
 - [GeeksforGeeks | A computer science portal for geeks](http://www.geeksforgeeks.org) : also subscribe to their feeds to get links to their new articles.
-- [A site for technical interview questions, brain teasers, puzzles, quizzles](http://www.techinterview.org) : whatever the heck those are) and other things that make you think!
+- [A site for technical interview questions, brain teasers, puzzles, quizzles](https://www.techinterview.org) : whatever the heck those are) and other things that make you think!
 - [Problems | LeetCode OJ](https://leetcode.com/problemset/algorithms) : Coding practice for interviews
 - [Programmer And Software Interview Questions Answers](http://www.programmerinterview.com)
 - [Reddit.com/user/ashish2199/m/puzzles](https://www.reddit.com/user/ashish2199/m/puzzles) : Logic Puzzles
@@ -114,15 +114,15 @@ When learning CS there are some useful sites you must know to get always informe
 - [Aptitude Questions and Answers](http://www.indiabix.com) : Quant and aptitude preparation
 - [Interview Archives - Java Honk](http://javahonk.com/category/interview)
 - [Top 10 Algorithms for Coding Interview](http://www.programcreek.com/2012/11/top-10-algorithms-for-coding-interview)
-- [Algorithm design canvas](http://www.hiredintech.com/algorithm-design))
+- [Algorithm design canvas](https://www.hiredintech.com/algorithm-design))
 - [Big-O Algorithm Complexity Cheat Sheet](http://bigocheatsheet.com/#)
 - [Unix / Linux Cheat Sheet](http://cheatsheetworld.com/programming/unix-linux-cheat-sheet)
 - [How to interview](http://kelukelu.me/interview/index.html)
 - [How to Ace an Algorithms Interview](http://www.palantir.com/2011/09/how-to-rock-an-algorithms-interview)
 - [Delightful Puzzles](http://gurmeet.net/puzzles)
-- [visualising data structures and algorithms through animation](http://visualgo.net)
+- [visualising data structures and algorithms through animation](https://visualgo.net)
 - [Here's How to Prepare for Tech Interviews • /r/cscareerquestions](https://www.reddit.com/r/cscareerquestions/comments/1jov24/heres_how_to_prepare_for_tech_interviews)
-- [Guide to Tech Interviews](http://www.kchodorow.com/blog/2013/02/28/guide-to-tech-interviews)
+- [Guide to Tech Interviews](https://www.kchodorow.com/blog/2013/02/28/guide-to-tech-interviews)
 - [Why You Make Less Money • /r/cscareerquestions](https://www.reddit.com/r/cscareerquestions/comments/1b8wa3/why_you_make_less_money)
 - [IIT Delhi Placement Experience](http://placement-iit2013.blogspot.in)
 - [what_are_your_goto_questions_for_the_do_you_have?](https://www.reddit.com/r/cscareerquestions/comments/209rkq/what_are_your_goto_questions_for_the_do_you_have)
@@ -133,24 +133,24 @@ When learning CS there are some useful sites you must know to get always informe
 - [The 25 most difficult HR questions](http://www.datsi.fi.upm.es/~frosal/docs/25mdq.html)
 - [Job interviews News, Videos, Reviews and Gossip - Lifehacker](http://lifehacker.com/tag/job-interviews)
 - [How to Answer the Toughest 40 Job Interview Questions | ICS Job Portal](http://www.icsjobportal.com/blog/job-interview-questions)
-- [Job Interview Questions and Best Answers](http://jobsearch.about.com/od/interviewquestionsanswers/a/interviewquest.htm)
+- [Job Interview Questions and Best Answers](https://www.thebalance.com/job-interview-questions-and-answers-2061204)
 - [How to Answer "Tell Me a Little About Yourself" | The Art of Manliness](http://www.artofmanliness.com/2016/01/05/tell-me-a-little-about-yourself)
 - [Job Interview: How to Ace a Job Interview | The Art of Manliness](http://www.artofmanliness.com/2012/08/06/how-to-ace-a-job-interview)
 - [Give your résumé a face lift](http://www.lifeclever.com/give-your-resume-a-face-lift)
 - [BIG O Misconceptions](http://ssp.impulsetrain.com/big-o.html)
 - [Bitwise tricks](https://gist.github.com/dideler/2365607)
 - [Core Java Interview questions - Interview question on each topic](http://javahonk.com/core-java-interview-questions)
-- [Java Interview Questions and Answers](http://adnjavainterview.blogspot.in)
+- [Java Interview Questions and Answers](https://adnjavainterview.blogspot.in)
 - [Big collection of interview preparation links • /r/cscareerquestions](https://www.reddit.com/r/cscareerquestions/comments/2lzc4h/big_collection_of_interview_preparation_links)
 - [Unsolicited_advice_for_job_seekers_and_employers](https://www.reddit.com/r/india/comments/1clgdj/unsolicited_advice_for_job_seekers_and_employers)
 - [five-essential-phone-screen-questions - steveyegge2](https://sites.google.com/site/steveyegge2/five-essential-phone-screen-questions)
 - [CS9: Problem-Solving for the CS Technical Interview](http://web.stanford.edu/class/cs9)
 - [Mission-peace/interview problems](https://github.com/mission-peace/interview/wiki) : A large collection of coding interview problems
 - [SQL Joins explained using venn diagram](http://stevestedman.com/wp-content/uploads/VennDiagram1.pdf)
-- [10 Frequently asked SQL Query Interview Questions](http://java67.blogspot.in/2013/04/10-frequently-asked-sql-query-interview-questions-answers-database.html)
+- [10 Frequently asked SQL Query Interview Questions](http://www.java67.com/2013/04/10-frequently-asked-sql-query-interview-questions-answers-database.html)
 - [Get Ready to Learn SQL: 8. Database Normalization Explained in Simple English - Essential SQL](http://www.essentialsql.com/get-ready-to-learn-sql-database-normalization-explained-in-simple-english)
 - [Programming Language Concepts: Lecture Notes](http://www.cmi.ac.in/~madhavan/courses/pl2006/lecturenotes/lecture-notes/lecture-notes.html) : OOPs concepts and programming language concepts.
-- [We Help Coders Get Hired](http://www.hiredintech.com/app) : website offering courses on system design, interview strategies, soft skills etc
+- [We Help Coders Get Hired](https://www.hiredintech.com/app) : website offering courses on system design, interview strategies, soft skills etc
 - [checkcheckzz/system-design-interview](https://github.com/checkcheckzz/system-design-interview)
 - [How to Break Into the Tech Industry - a Guide to Job Hunting and Tech Interviews](http://haseebq.com/how-to-break-into-tech-job-hunting-and-interviews)
 - [Freshers Interviews](http://placementsindia.blogspot.in)
@@ -160,13 +160,13 @@ When learning CS there are some useful sites you must know to get always informe
 - [https://github.com/odino/interviews](https://github.com/odino/interviews) : list of important questions for interview
 - [svozniuk/java-interviews](https://github.com/svozniuk/java-interviews) : Java interview questions
 - [kimberli/interviews](https://github.com/kimberli/interviews) : study sheet for Interview
-- [Determining the big-O runtimes of these different loops?](http://stackoverflow.com/questions/11094330/determining-the-big-o-runtimes-of-these-different-loops) : really good stackoverflow question that covers basics of calculating runtime complexity.
+- [Determining the big-O runtimes of these different loops?](https://stackoverflow.com/questions/11094330/determining-the-big-o-runtimes-of-these-different-loops) : really good stackoverflow question that covers basics of calculating runtime complexity.
 - [ChiperSoft/InterviewThis](https://github.com/ChiperSoft/InterviewThis) : questions to ask during on a interview to know more about the company.
 - [SQL interview questions](https://www.jitbit.com/news/181-jitbits-sql-interview-questions) : great SQL test
 
 ## Documentaries
 - Machine that Changed the World - a very good documentary about history of computers
-  - [Part 1: Giant Brains](http://www.youtube.com/watch?v=rcR74y61xZk)
+  - [Part 1: Giant Brains](https://www.youtube.com/watch?v=rcR74y61xZk)
   - [Part 2: Inventing the Future](https://www.youtube.com/watch?v=0iPiYxjsYKk)
   - [Part 3: The Paperback Computer](https://www.youtube.com/watch?v=d7DKVfOXr54)
   - [Part 4: The Thinking Machine](https://www.youtube.com/watch?v=enWWlx7-t0k)
@@ -189,13 +189,13 @@ When learning CS there are some useful sites you must know to get always informe
 ## MOOCs for learning something new
 - [Class Central](https://www.class-central.com) : a directory of 100,000+ student reviews of thousands of MOOCs.
 - [NPTEL Vidoes COMP_SCI_ENGG](https://onlinecourses.nptel.ac.in/explorer/search?category=COMP_SCI_ENGG)
-- [Coursera.org](http://coursera.org)
-- [edX](http://edx.org)
+- [Coursera.org](https://coursera.org)
+- [edX](https://www.edx.org)
 - [MOOC.fi](http://mooc.fi/english.html) : Free online courses from the University of Helsinki
-- [Udacity](http://udacity.com)
+- [Udacity](https://www.udacity.com)
 - [Kadenze | Creative Programming](https://www.kadenze.com/courses?subjects%5B%5D=7): Programming courses focused on art and creativity
 - [UCBerkeley](https://www.youtube.com/user/UCBerkeley/videos)
-- [MIT OCW Electrical Engineering and Computer Science](http://ocw.mit.edu/courses/electrical-engineering-and-computer-science)
+- [MIT OCW Electrical Engineering and Computer Science](https://ocw.mit.edu/courses/electrical-engineering-and-computer-science)
 - [CS50](https://www.youtube.com/user/cs50tv/videos)
 - [prakhar1989/awesome-CS-courses](https://github.com/prakhar1989/awesome-courses/blob/master/README.md) : List containing large amount of CS courses
 - [Computer Science Resources](https://docs.google.com/spreadsheets/d/1BD8BJJUNaX63m2QmySWMGDp71nx4W4MyyiIBlfMoN3Q/htmlview?sle=true#) : list of MOOCs for autodidacts
@@ -209,8 +209,8 @@ When learning CS there are some useful sites you must know to get always informe
 - [Java Lecture Notes](http://www.cafeaulait.org/course)
 - [Learning Java](http://chimera.labs.oreilly.com/books/1234000001805/index.html) : a free online textbook for learning Java
 - [Free Online Chapters of Inside the Java Virtual Machine by Bill Venners](http://www.artima.com/insidejvm/ed2/index.html)
-- [Understanding JVM Internals](http://www.cubrid.org/blog/dev-platform/understanding-jvm-internals)
-- [How Garbage Collection Works](http://www.dynatrace.com/en/javabook/how-garbage-collection-works.html)
+- [Understanding JVM Internals](http://www.cubrid.org/blog/understanding-jvm-internals)
+- [How Garbage Collection Works](https://www.dynatrace.com/resources/ebooks/javabook/how-garbage-collection-works)
 - [Welcome to JavaWorld.com](http://www.javaworld.com)
 - [The Java Memory Model](http://www.cs.umd.edu/~pugh/java/memoryModel)
 - [Netbeans Keyboard Shortcuts](https://netbeans.org/project_downloads/usersguide/shortcuts-80.pdf) : Keyboard shortcuts to enhance your productivity when working in Netbeans.
@@ -267,9 +267,10 @@ When learning CS there are some useful sites you must know to get always informe
 - [HowToBecomeTV](https://www.youtube.com/user/HowToBecomeTV/videos) : contains good interviews of developers and people related to tech industry.
 - [Siraj Raval](https://www.youtube.com/channel/UCWN3xxRkmTPmbKwht9FuE5A) : Artificial Intelligence and deep learning tutorials videos
 - [Netflix UI Engineering](https://www.youtube.com/channel/UCGGRRqAjPm6sL3-WGBDnKJA/videos) : great videos to watch for web developers, mobile developers and those interested in some of Netflix's tech stack
-- [Coding Blocks](https://www.youtube.com/CodingBlocks) : Tutorials, how to's, tips and tricks
-- [Codely tv](https://www.youtube.com/UC9IKtxn9AIGelnYmwYr0Lxw) : Interviews, tips and tricks
+- [Coding Blocks](https://www.youtube.com/user/codingblocks) : Tutorials, how to's, tips and tricks
 - [Fun Fun Function](https://www.youtube.com/c/mpjmevideos) : A weekly series from Mattias Petter Johansson on an assortment of programming topics, including some not directly related to coding.
+
+<!--- [Codely tv](https://www.youtube.com/UC9IKtxn9AIGelnYmwYr0Lxw) : Interviews, tips and tricks-->
 
 ## Good Articles
 - [Expectations of a Junior Developer](http://blog.thefirehoseproject.com/posts/expectations-of-a-junior-developer)
@@ -313,14 +314,14 @@ When learning CS there are some useful sites you must know to get always informe
 ## Tutorials
 - [Subtle | Poor Man's CI](https://www.subtle.press/course/poor-mans-ci) : Learn how continuous integration platforms work under the hood, by building one of your own on top of git with Node.js
 - [Tutorialspoint](http://www.tutorialspoint.com)
-- [W3Schools Online Web Tutorials](http://www.w3schools.com)
+- [W3Schools Online Web Tutorials](https://www.w3schools.com)
 - [Open Data Structures](http://opendatastructures.org) : Excellent resource for learning about DS and algos , provides code in various languages C++ , Java , pseudocode
 - [Data Structures and Algorithms by John Morris](http://oopweb.com/Algorithms/Documents/PLDS210/VolumeFrames.html) : another good source with code and its analysis
 - [CMSI 281: Data Structures](http://cs.lmu.edu/~ray/classes/dsa) : light weight introduction to DS
 - [How to Program in C++](http://cs.fit.edu/~mmahoney/cse2050/how2cpp.html) : Good resource for revising C++ topics and STL
 - [TopCoder Tutorials](https://www.topcoder.com/community/data-science/data-science-tutorials)
-- [A Hacker's Guide to Git](http://wildlyinaccurate.com/a-hackers-guide-to-git) : for those wanting to learn git with a solid foundation
-- [Git from the inside out](http://maryrosecook.com/blog/post/git-from-the-inside-out)
+- [A Hacker's Guide to Git](https://wildlyinaccurate.com/a-hackers-guide-to-git) : for those wanting to learn git with a solid foundation
+- [Git from the inside out](https://maryrosecook.com/blog/post/git-from-the-inside-out)
 - [Learn UNIX in 10 minutes](http://freeengineer.org/learnUNIXin10minutes.html)
 - [The Bash Guide](http://guide.bash.academy) : very good guide for learning the Bash Shell
 - [Linux Tutorial](http://ryanstutorials.net/linuxtutorial) : good resource for learning Linux
@@ -328,7 +329,7 @@ When learning CS there are some useful sites you must know to get always informe
 - [Linux Tutorial for Beginners](http://www.ee.surrey.ac.uk/Teaching/Unix)
 - [Learning the shell.](http://linuxcommand.org/learning_the_shell.php)
 - [Dynamic programming - PrismoSkills](http://prismoskills.appspot.com/lessons/Dynamic_Programming/Chapter_01_-_Introduction.jsp) : very good resource if want to learn how to solve DP problems.
-- [Deep C](http://www.slideshare.net/olvemaudal/deep-c) : very good presentation on C language
+- [Deep C](https://www.slideshare.net/olvemaudal/deep-c) : very good presentation on C language
 - [C programming language Frequently Asked Questions](http://c-faq.com/index.html)
 - [OS Course Notes](https://www.cs.uic.edu/~jbell/CourseNotes/OperatingSystems) : Chapter wise course notes according to Galvin's book
 - [SQL (Structured Query Language) in one page : SQL.SU](http://www.cheat-sheets.org/sites/sql.su) : a very good SQL cheat sheet
@@ -337,17 +338,17 @@ When learning CS there are some useful sites you must know to get always informe
 - [http://www.mysqltutorial.org/](http://www.mysqltutorial.org)
 - [Best Of - Gustavo Duarte](http://duartes.org/gustavo/blog/best-of) : contains articles on various topics
 - [Collecting all the cheat sheets](http://overapi.com) : cheat sheets for lots of programming languages
-- [The Descent to C](http://www.chiark.greenend.org.uk/~sgtatham/cdescent) : for those moving to C from some higher programming language like java or python.
+- [The Descent to C](https://www.chiark.greenend.org.uk/~sgtatham/cdescent) : for those moving to C from some higher programming language like java or python.
 - [VimTutor+](https://vimtutorplus.herokuapp.com/exercise/1) : learn VIM from browser itself
 - [HackerEarth Tutorials](https://learn.hackerearth.com/tutorials) : Good resource for DS and Algos tutorial
 - [Linux Journey](https://linuxjourney.com) : good site for learning linux
-- [C Programming](http://www.cs.cf.ac.uk/Dave/C/CE.html)
+- [C Programming](http://users.cs.cf.ac.uk/dave/C/CE.html)
 - [CS 2112/ENGRD 2112 Fall 2015](http://www.cs.cornell.edu/courses/cs2112/2015fa/lectures/index.html) : Good notes on data structures and algorithms.
 - [More about Github-flavored markdown](https://guides.github.com/features/mastering-markdown)
 - [The Unix Programming Environment](http://product.half.ebay.com/The-UNIX-Programming-Environment-by-Brian-W-Kernighan-and-Rob-Pike-1983-Other/54385&tg=info)
-- [The Linux Command Line: A Complete Introduction](https://www.amazon.com/dp/1593273894)
+- [The Linux Command Line: A Complete Introduction](https://www.amazon.com/Linux-Command-Line-Complete-Introduction/dp/1593273894)
 - [TCP/IP Illustrated Series](https://en.wikipedia.org/wiki/TCP/IP_Illustrated)
-- [Head First Design Patterns](https://www.amazon.com/gp/product/0596007124)
+- [Head First Design Patterns](https://www.amazon.com/Head-First-Design-Patterns-Brain-Friendly/dp/0596007124 )
 - [Design Patterns: Elements of Reusable Object-Oriented Software](https://www.amazon.com/Design-Patterns-Elements-Reusable-Object-Oriented/dp/0201633612) : aka the "Gang Of Four" book, or GOF
 - [UNIX and Linux System Administration Handbook, 4th Edition](https://www.amazon.com/UNIX-Linux-System-Administration-Handbook/dp/0131480057)
 - [Programming, Web Development, and DevOps news, tutorials and tools for beginners to experts](https://dzone.com)
@@ -359,19 +360,19 @@ When learning CS there are some useful sites you must know to get always informe
 ## What should a programmer know
 - [Programmer Competency Matrix](http://sijinjoseph.com/programmer-competency-matrix) : article for knowing what our level as a programmer is.
 - [GitHub.com Build software better, together](https://github.com) : Place to showcase your project and collaborate with others. (Must know Git in order to use it effectively)
-- [Gitlab offers free unlimited (private) repositories and unlimited collaborators](https://gitlab.com).
+- [Gitlab offers free unlimited (private) repositories and unlimited collaborators](https://about.gitlab.com).
 
 ## Competitive programming
 - [WakaTime](https://wakatime.com) : leaderboards of coding metrics collected via editor plugins
-- [HackerRank](http://hackerrank.com)
+- [HackerRank](https://www.hackerrank.com)
 - [Codeforces](http://codeforces.com)
-- [topcoder](http://topcoder.com)
+- [topcoder](http://www.topcoder.com)
 - [UVa Online Judge](https://uva.onlinejudge.org) : hundreds of problems supporting multiple languages.
-- [HackerEarth - Programming challenges and Developer jobs](http://hackerearth.com)
-- [CodeChef](http://codechef.com)
+- [HackerEarth - Programming challenges and Developer jobs](https://www.hackerearth.com)
+- [CodeChef](http://www.codechef.com)
 - [PKU ACM ICPC Practice problems](http://poj.org/problemlist)
 - [Archived Problems - Project Euler](https://projecteuler.net/archives)
-- [Google Code Jam Practice and](https://code.google.com/codejam/contests.html) : past contest problems for practice
+- [Google Code Jam Practice and](https://code.google.com/codejam/past-contests) : past contest problems for practice
 - [Sphere Online Judge (SPOJ)](http://www.spoj.com)
 - [Art of Problem Solving](https://artofproblemsolving.com)
 - [Riddles.io AI Games](https://www.riddles.io) : Compete with your bot and dominate the leaderboards!
@@ -381,9 +382,9 @@ When learning CS there are some useful sites you must know to get always informe
 
 ## Computer Books
 - [IT eBooks - Free Download - Big Library](http://it-ebooks.info) : website for downloading ebooks without any advertisement and instant downloads.
-- [github.com/vhf/free-programming-books](https://github.com/vhf/free-programming-books/blob/master/free-programming-books.md) : More than 500 free ebooks on almost any language you can think of
+- [github.com/vhf/free-programming-books](https://github.com/EbookFoundation/free-programming-books/blob/master/free-programming-books.md) : More than 500 free ebooks on almost any language you can think of
 - [Computer Science Books Online](http://www.sciencebooksonline.info/computer-science.html) : about 150 computer free ebooks
-- [Best books for GATE CSE](http://gatecse.in/wiki/Best_books_for_CSE#Best_Books_for_GATE_in_CSE)
+- [Best books for GATE CSE](http://www.gatecse.in/best-books-for-gate)
 - [https://cses.fi/book.html](https://cses.fi/book.html)
 - [Library Genesis](http://gen.lib.rus.ec) : Almost any ebook you can think of, including countless CS texts and manuals.
 
@@ -394,7 +395,7 @@ When learning CS there are some useful sites you must know to get always informe
 - [mycodeschool](https://www.youtube.com/user/mycodeschool/videos) : Data structures and algorithms tutorials
 - [CodeGeek](https://www.youtube.com/channel/UCJYhP1lceSUc1bg0LRBUvqA/videos)
 - [CodingMadeEasy](https://www.youtube.com/user/CodingMadeEasy/videos) : C++ tutorials
-- [XDA-University - Helping You Learn Android Development](http://xda-university.com)
+- [XDA-University - Helping You Learn Android Development](https://forum.xda-developers.com/general/xda-university)
 - [DevTips](https://www.youtube.com/user/DevTipsForDesigners/videos) : web dev tutorials
 - [codedamn](https://www.youtube.com/channel/UCJUmE61LxhbhudzUugHL2wQ/videos) : front end web dev tutorials
 - [Design and Analysis of Algorithms](http://openclassroom.stanford.edu/MainFolder/CoursePage.php?course=IntroToAlgorithms)
@@ -406,15 +407,15 @@ When learning CS there are some useful sites you must know to get always informe
 - [CodePad](https://codepad.remoteinterview.io) : Code editor to try, test and run 25+ languages
 - [JSFiddle](https://jsfiddle.net) : Test your JavaScript, CSS, HTML or CoffeeScript with online code editor
 - [Ideone.com](https://ideone.com)
-- [Pastebin.com](http://pastebin.com)
+- [Pastebin.com](https://pastebin.com)
 - [Godbolt.org](https://godbolt.org): Excellent tool for exploring the assembly output of different compilers with and without optimization.
 
 ## Blogs of Developers
-- [Coding Horror](http://blog.codinghorror.com) : one the best coding blog
+- [Coding Horror](https://blog.codinghorror.com) : one the best coding blog
 - [WildMl](http://www.wildml.com) : A blog for machine learning.
 - [Armin Ronacher's Thoughts and Writings](http://lucumr.pocoo.org) : blog on Python and open source
 - [Eli Bendersky](http://eli.thegreenplace.net) : everything from Python to LLVM
-- [Joel on Software](http://joelonsoftware.com)
+- [Joel on Software](http://www.joelonsoftware.com)
 - [Stephen Haunts { Coding in the Trenches }](https://stephenhaunts.com)
 - [Programming in the 21st Century](http://prog21.dadgum.com)
 - [Clean Coder Blog](http://blog.cleancoder.com) : blog of author of book "Clean Code"
@@ -433,9 +434,9 @@ When learning CS there are some useful sites you must know to get always informe
 - [CoderGears Blog Insights from](http://www.codergears.com/Blog) : the CoderGears Team
 - [Runhe Tian Coding Practice](https://tianrunhe.wordpress.com)
 - [Paul Graham Essays](http://www.paulgraham.com/articles.html)
-- [Dan Dreams of Coding](http://dandreamsofcoding.com)
+- [Dan Dreams of Coding](https://dandreamsofcoding.com)
 - [Antonio081014's Algorithms Codes](http://code.antonio081014.com)
-- [Math ∩ Programming](http://jeremykun.com)
+- [Math ∩ Programming](https://jeremykun.com)
 - [Takipi Blog](http://blog.takipi.com) : mainly focuses on Java and JVM languages
 - [Coding Geek - A blog about IT, programming and Java](http://coding-geek.com)
 - [Daedtech.com](http://www.daedtech.com) : Stories about software
@@ -463,6 +464,6 @@ When learning CS there are some useful sites you must know to get always informe
 - [Big Think](https://www.youtube.com/user/bigthink/videos) : Expert driven, actionable, educational content, featuring experts ranging from Bill Clinton to Bill Nye
 - [Every Frame a Painting](https://www.youtube.com/user/everyframeapainting/videos) : High quality analysis of films and filmmaking
 - [TestTube News](https://www.youtube.com/user/TestTubeNetwork/videos) : Interesting information about news from around the world
-- [Reddit the front page of the internet](http://reddit.com) : Where free time goes to die
+- [Reddit the front page of the internet](https://www.reddit.com) : Where free time goes to die
 
   **Maintained with :heart: by sdmg15 & al**

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ When learning CS there are some useful sites you must know to get always informe
 - [Lobsters](https://lobste.rs) : Lobsters is a technology-focused community centered around link aggregation and discussion.
 - [TechCrunch](http://techcrunch.com) : another good website for tech news
 - [GSMArena.com](http://gsmarena.com) : news related to latest mobile phones and android.
-- [product hunt ](https://www.producthunt.com) : Discover your next favorite thing
+- [product hunt](https://www.producthunt.com) : Discover your next favorite thing
 - [AlternativeTo](https://alternativeto.net) : Crowdsourced software recommendations
 - [Better Dev Links](https://betterdev.link) : Weekly links to help you become a better developer
 
@@ -107,7 +107,7 @@ When learning CS there are some useful sites you must know to get always informe
 ### Interview Preparation
 - [GeeksforGeeks | A computer science portal for geeks](http://www.geeksforgeeks.org) : also subscribe to their feeds to get links to their new articles.
 - [A site for technical interview questions, brain teasers, puzzles, quizzles](http://www.techinterview.org) : whatever the heck those are) and other things that make you think!
-- [Problems | LeetCode OJ ](https://leetcode.com/problemset/algorithms) : Coding practice for interviews
+- [Problems | LeetCode OJ](https://leetcode.com/problemset/algorithms) : Coding practice for interviews
 - [Programmer And Software Interview Questions Answers](http://www.programmerinterview.com)
 - [Reddit.com/user/ashish2199/m/puzzles](https://www.reddit.com/user/ashish2199/m/puzzles) : Logic Puzzles
 - [A Collection of Quant Riddles With Answers](http://puzzles.nigelcoldwell.co.uk)
@@ -119,7 +119,7 @@ When learning CS there are some useful sites you must know to get always informe
 - [Unix / Linux Cheat Sheet](http://cheatsheetworld.com/programming/unix-linux-cheat-sheet)
 - [How to interview](http://kelukelu.me/interview/index.html)
 - [How to Ace an Algorithms Interview](http://www.palantir.com/2011/09/how-to-rock-an-algorithms-interview)
-- [Delightful Puzzles ](http://gurmeet.net/puzzles)
+- [Delightful Puzzles](http://gurmeet.net/puzzles)
 - [visualising data structures and algorithms through animation](http://visualgo.net)
 - [Here's How to Prepare for Tech Interviews • /r/cscareerquestions](https://www.reddit.com/r/cscareerquestions/comments/1jov24/heres_how_to_prepare_for_tech_interviews)
 - [Guide to Tech Interviews](http://www.kchodorow.com/blog/2013/02/28/guide-to-tech-interviews)
@@ -130,33 +130,33 @@ When learning CS there are some useful sites you must know to get always informe
 - [Interviewing At Jane Street](https://blogs.janestreet.com/interviewing-at-jane-street)
 - [How to prepare for an interview - 1](http://se7so.blogspot.in/2014/01/how-to-prepare-for-interview-1.html)
 - [Summer Internship: The Ultimate Guide](eulercoder.me/blog/career/Summer-Internship-the-ultimate-guide)
-- [The 25 most difficult HR questions ](http://www.datsi.fi.upm.es/~frosal/docs/25mdq.html)
-- [Job interviews News, Videos, Reviews and Gossip - Lifehacker ](http://lifehacker.com/tag/job-interviews)
-- [How to Answer the Toughest 40 Job Interview Questions | ICS Job Portal ](http://www.icsjobportal.com/blog/job-interview-questions)
-- [Job Interview Questions and Best Answers ](http://jobsearch.about.com/od/interviewquestionsanswers/a/interviewquest.htm)
-- [How to Answer "Tell Me a Little About Yourself" | The Art of Manliness ](http://www.artofmanliness.com/2016/01/05/tell-me-a-little-about-yourself)
-- [Job Interview: How to Ace a Job Interview | The Art of Manliness ](http://www.artofmanliness.com/2012/08/06/how-to-ace-a-job-interview)
-- [Give your résumé a face lift ](http://www.lifeclever.com/give-your-resume-a-face-lift)
-- [BIG O Misconceptions ](http://ssp.impulsetrain.com/big-o.html)
-- [Bitwise tricks ](https://gist.github.com/dideler/2365607)
-- [Core Java Interview questions - Interview question on each topic ](http://javahonk.com/core-java-interview-questions)
-- [Java Interview Questions and Answers ](http://adnjavainterview.blogspot.in)
-- [Big collection of interview preparation links • /r/cscareerquestions ](https://www.reddit.com/r/cscareerquestions/comments/2lzc4h/big_collection_of_interview_preparation_links)
-- [Unsolicited_advice_for_job_seekers_and_employers ](https://www.reddit.com/r/india/comments/1clgdj/unsolicited_advice_for_job_seekers_and_employers)
-- [five-essential-phone-screen-questions - steveyegge2 ](https://sites.google.com/site/steveyegge2/five-essential-phone-screen-questions)
-- [CS9: Problem-Solving for the CS Technical Interview ](http://web.stanford.edu/class/cs9)
-- [Mission-peace/interview problems ](https://github.com/mission-peace/interview/wiki) : A large collection of coding interview problems
-- [SQL Joins explained using venn diagram ](http://stevestedman.com/wp-content/uploads/VennDiagram1.pdf)
-- [10 Frequently asked SQL Query Interview Questions ](http://java67.blogspot.in/2013/04/10-frequently-asked-sql-query-interview-questions-answers-database.html)
-- [Get Ready to Learn SQL: 8. Database Normalization Explained in Simple English - Essential SQL ](http://www.essentialsql.com/get-ready-to-learn-sql-database-normalization-explained-in-simple-english)
-- [Programming Language Concepts: Lecture Notes ](http://www.cmi.ac.in/~madhavan/courses/pl2006/lecturenotes/lecture-notes/lecture-notes.html) : OOPs concepts and programming language concepts.
+- [The 25 most difficult HR questions](http://www.datsi.fi.upm.es/~frosal/docs/25mdq.html)
+- [Job interviews News, Videos, Reviews and Gossip - Lifehacker](http://lifehacker.com/tag/job-interviews)
+- [How to Answer the Toughest 40 Job Interview Questions | ICS Job Portal](http://www.icsjobportal.com/blog/job-interview-questions)
+- [Job Interview Questions and Best Answers](http://jobsearch.about.com/od/interviewquestionsanswers/a/interviewquest.htm)
+- [How to Answer "Tell Me a Little About Yourself" | The Art of Manliness](http://www.artofmanliness.com/2016/01/05/tell-me-a-little-about-yourself)
+- [Job Interview: How to Ace a Job Interview | The Art of Manliness](http://www.artofmanliness.com/2012/08/06/how-to-ace-a-job-interview)
+- [Give your résumé a face lift](http://www.lifeclever.com/give-your-resume-a-face-lift)
+- [BIG O Misconceptions](http://ssp.impulsetrain.com/big-o.html)
+- [Bitwise tricks](https://gist.github.com/dideler/2365607)
+- [Core Java Interview questions - Interview question on each topic](http://javahonk.com/core-java-interview-questions)
+- [Java Interview Questions and Answers](http://adnjavainterview.blogspot.in)
+- [Big collection of interview preparation links • /r/cscareerquestions](https://www.reddit.com/r/cscareerquestions/comments/2lzc4h/big_collection_of_interview_preparation_links)
+- [Unsolicited_advice_for_job_seekers_and_employers](https://www.reddit.com/r/india/comments/1clgdj/unsolicited_advice_for_job_seekers_and_employers)
+- [five-essential-phone-screen-questions - steveyegge2](https://sites.google.com/site/steveyegge2/five-essential-phone-screen-questions)
+- [CS9: Problem-Solving for the CS Technical Interview](http://web.stanford.edu/class/cs9)
+- [Mission-peace/interview problems](https://github.com/mission-peace/interview/wiki) : A large collection of coding interview problems
+- [SQL Joins explained using venn diagram](http://stevestedman.com/wp-content/uploads/VennDiagram1.pdf)
+- [10 Frequently asked SQL Query Interview Questions](http://java67.blogspot.in/2013/04/10-frequently-asked-sql-query-interview-questions-answers-database.html)
+- [Get Ready to Learn SQL: 8. Database Normalization Explained in Simple English - Essential SQL](http://www.essentialsql.com/get-ready-to-learn-sql-database-normalization-explained-in-simple-english)
+- [Programming Language Concepts: Lecture Notes](http://www.cmi.ac.in/~madhavan/courses/pl2006/lecturenotes/lecture-notes/lecture-notes.html) : OOPs concepts and programming language concepts.
 - [We Help Coders Get Hired](http://www.hiredintech.com/app) : website offering courses on system design, interview strategies, soft skills etc
 - [checkcheckzz/system-design-interview](https://github.com/checkcheckzz/system-design-interview)
-- [How to Break Into the Tech Industry - a Guide to Job Hunting and Tech Interviews ](http://haseebq.com/how-to-break-into-tech-job-hunting-and-interviews)
+- [How to Break Into the Tech Industry - a Guide to Job Hunting and Tech Interviews](http://haseebq.com/how-to-break-into-tech-job-hunting-and-interviews)
 - [Freshers Interviews](http://placementsindia.blogspot.in)
-- [C PUZZLES, Some interesting C problems ](http://www.gowrikumar.com/c/index.php)
-- [A site for technical interview questions, brain teasers, puzzles, quizzles (whatever the heck those are) and other things that make you think! ](http://www.techinterview.org)
-- [ wu :: riddles(hard) ](https://www.ocf.berkeley.edu/~wwu/riddles/hard.shtml) : logic puzzles and riddles
+- [C PUZZLES, Some interesting C problems](http://www.gowrikumar.com/c/index.php)
+- [A site for technical interview questions, brain teasers, puzzles, quizzles (whatever the heck those are) and other things that make you think!](http://www.techinterview.org)
+- [wu :: riddles(hard)](https://www.ocf.berkeley.edu/~wwu/riddles/hard.shtml) : logic puzzles and riddles
 - [https://github.com/odino/interviews](https://github.com/odino/interviews) : list of important questions for interview
 - [svozniuk/java-interviews](https://github.com/svozniuk/java-interviews) : Java interview questions
 - [kimberli/interviews](https://github.com/kimberli/interviews) : study sheet for Interview
@@ -166,18 +166,18 @@ When learning CS there are some useful sites you must know to get always informe
 
 ## Documentaries
 - Machine that Changed the World - a very good documentary about history of computers
-      * [Part 1: Giant Brains ](http://www.youtube.com/watch?v=rcR74y61xZk)
+      * [Part 1: Giant Brains](http://www.youtube.com/watch?v=rcR74y61xZk)
       * [Part 2: Inventing the Future](https://www.youtube.com/watch?v=0iPiYxjsYKk)
       * [Part 3: The Paperback Computer](https://www.youtube.com/watch?v=d7DKVfOXr54)
       * [Part 4: The Thinking Machine](https://www.youtube.com/watch?v=enWWlx7-t0k)
       * [Part 5: The World at Your Fingertips](https://www.youtube.com/watch?v=fLLXiP7diEo)
-- [Triumph of the Nerds ](https://www.youtube.com/playlist?list=PLn-Y3vvQbmHO5WUcBdIWqiUfNawhC1cn3) : Play-list
-- [Project Code Rush - The Beginnings of Netscape / Mozilla Documentary ](https://www.youtube.com/watch?v=a-49a_CjH0M)
-- [The Code: Story of Linux documentary ](https://www.youtube.com/watch?v=XMm0HsmOTFI)
-- [Breaking the Code: Biography of Alan Turing ](https://www.youtube.com/watch?v=S23yie-779k)
-- [Mechanical Computer (All Parts) ](https://www.youtube.com/watch?v=s1i-dnAH9Y4) : a very good video from 1950s explaining how mechanical computers used to work without all the modern day electronics.
-- [Download: The True Story of the Internet ](https://www.youtube.com/playlist?list=PL_IlIlrxhtPMqW4b0-v8OgLvFZQes6SoZ) : Play-list of discovery channel documentary on browser wars , dot com bubble and more.
-- [Teach Yourself Computer Science ](https://teachyourselfcs.com)
+- [Triumph of the Nerds](https://www.youtube.com/playlist?list=PLn-Y3vvQbmHO5WUcBdIWqiUfNawhC1cn3) : Play-list
+- [Project Code Rush - The Beginnings of Netscape / Mozilla Documentary](https://www.youtube.com/watch?v=a-49a_CjH0M)
+- [The Code: Story of Linux documentary](https://www.youtube.com/watch?v=XMm0HsmOTFI)
+- [Breaking the Code: Biography of Alan Turing](https://www.youtube.com/watch?v=S23yie-779k)
+- [Mechanical Computer (All Parts)](https://www.youtube.com/watch?v=s1i-dnAH9Y4) : a very good video from 1950s explaining how mechanical computers used to work without all the modern day electronics.
+- [Download: The True Story of the Internet](https://www.youtube.com/playlist?list=PL_IlIlrxhtPMqW4b0-v8OgLvFZQes6SoZ) : Play-list of discovery channel documentary on browser wars , dot com bubble and more.
+- [Teach Yourself Computer Science](https://teachyourselfcs.com)
 - [How does CPU execute program (video)](https://www.youtube.com/watch?v=42KTvGYQYnA)
 - [Machine Code Instructions (video)](https://www.youtube.com/watch?v=Mv2XQgpbTNE)
 - [Harvard CS50 - Asymptotic Notation (video)](https://www.youtube.com/watch?v=iOq5kSKqeR4)
@@ -188,7 +188,7 @@ When learning CS there are some useful sites you must know to get always informe
 
 ## MOOCs for learning something new
 - [Class Central](https://www.class-central.com) : a directory of 100,000+ student reviews of thousands of MOOCs.
-- [NPTEL Vidoes COMP_SCI_ENGG ](https://onlinecourses.nptel.ac.in/explorer/search?category=COMP_SCI_ENGG)
+- [NPTEL Vidoes COMP_SCI_ENGG](https://onlinecourses.nptel.ac.in/explorer/search?category=COMP_SCI_ENGG)
 - [Coursera.org](http://coursera.org)
 - [edX](http://edx.org)
 - [MOOC.fi](http://mooc.fi/english.html) : Free online courses from the University of Helsinki
@@ -198,26 +198,26 @@ When learning CS there are some useful sites you must know to get always informe
 - [MIT OCW Electrical Engineering and Computer Science](http://ocw.mit.edu/courses/electrical-engineering-and-computer-science)
 - [CS50](https://www.youtube.com/user/cs50tv/videos)
 - [prakhar1989/awesome-CS-courses](https://github.com/prakhar1989/awesome-courses/blob/master/README.md) : List containing large amount of CS courses
-- [Computer Science Resources ](https://docs.google.com/spreadsheets/d/1BD8BJJUNaX63m2QmySWMGDp71nx4W4MyyiIBlfMoN3Q/htmlview?sle=true#) : list of MOOCs for autodidacts
-- [https://github.com/prakhar1989/awesome-courses/blob/master/README.md ](https://github.com/prakhar1989/awesome-courses/blob/master/README.md) : collection of CS courses on Internet
+- [Computer Science Resources](https://docs.google.com/spreadsheets/d/1BD8BJJUNaX63m2QmySWMGDp71nx4W4MyyiIBlfMoN3Q/htmlview?sle=true#) : list of MOOCs for autodidacts
+- [https://github.com/prakhar1989/awesome-courses/blob/master/README.md](https://github.com/prakhar1989/awesome-courses/blob/master/README.md) : collection of CS courses on Internet
 
 ## Sites related to your preferred programming language (For me Java)
-- [Java Revisited ](http://javarevisited.blogspot.in) : good for learning about Java Language and interview preparation.
-- [The Java™ Tutorials  ](https://docs.oracle.com/javase/tutorial): The best tutorials for Java.
-- [Java Corner at Artima.com ](http://www.artima.com/java/index.html)
-- [Java Visualizer ](http://www.cs.princeton.edu/~cos126/java_visualize) : helps visualize references , values of variables ect
-- [Java Lecture Notes ](http://www.cafeaulait.org/course)
-- [Learning Java ](http://chimera.labs.oreilly.com/books/1234000001805/index.html) : a free online textbook for learning Java
-- [Free Online Chapters of Inside the Java Virtual Machine by Bill Venners ](http://www.artima.com/insidejvm/ed2/index.html)
-- [Understanding JVM Internals ](http://www.cubrid.org/blog/dev-platform/understanding-jvm-internals)
-- [How Garbage Collection Works ](http://www.dynatrace.com/en/javabook/how-garbage-collection-works.html)
-- [Welcome to JavaWorld.com ](http://www.javaworld.com)
-- [The Java Memory Model ](http://www.cs.umd.edu/~pugh/java/memoryModel)
-- [Netbeans Keyboard Shortcuts ](https://netbeans.org/project_downloads/usersguide/shortcuts-80.pdf) : Keyboard shortcuts to enhance your productivity when working in Netbeans.
-- [XyzWs Java FAQs ](http://www.xyzws.com/javafaq/page/1) : large collection of java interview questions
-- [Search Open Source Java API ](http://www.docjar.com) : view source of java library and learn how things are implemented.
+- [Java Revisited](http://javarevisited.blogspot.in) : good for learning about Java Language and interview preparation.
+- [The Java™ Tutorials](https://docs.oracle.com/javase/tutorial): The best tutorials for Java.
+- [Java Corner at Artima.com](http://www.artima.com/java/index.html)
+- [Java Visualizer](http://www.cs.princeton.edu/~cos126/java_visualize) : helps visualize references , values of variables ect
+- [Java Lecture Notes](http://www.cafeaulait.org/course)
+- [Learning Java](http://chimera.labs.oreilly.com/books/1234000001805/index.html) : a free online textbook for learning Java
+- [Free Online Chapters of Inside the Java Virtual Machine by Bill Venners](http://www.artima.com/insidejvm/ed2/index.html)
+- [Understanding JVM Internals](http://www.cubrid.org/blog/dev-platform/understanding-jvm-internals)
+- [How Garbage Collection Works](http://www.dynatrace.com/en/javabook/how-garbage-collection-works.html)
+- [Welcome to JavaWorld.com](http://www.javaworld.com)
+- [The Java Memory Model](http://www.cs.umd.edu/~pugh/java/memoryModel)
+- [Netbeans Keyboard Shortcuts](https://netbeans.org/project_downloads/usersguide/shortcuts-80.pdf) : Keyboard shortcuts to enhance your productivity when working in Netbeans.
+- [XyzWs Java FAQs](http://www.xyzws.com/javafaq/page/1) : large collection of java interview questions
+- [Search Open Source Java API](http://www.docjar.com) : view source of java library and learn how things are implemented.
 - [JournalDev - Java, Java EE, Android, Web Development Tutorials](http://www.journaldev.com)
-- [Implementation of Algorithms and Data Structures, Interview Questions and Answers ](https://github.com/sherxon/AlgoDS)
+- [Implementation of Algorithms and Data Structures, Interview Questions and Answers](https://github.com/sherxon/AlgoDS)
 - [what-is-garbage-collection](https://plumbr.eu/handbook/what-is-garbage-collection) : Demystify the garbage collection
 - [Best books for learning java must read](https://javahungry.blogspot.com/2014/02/best-books-for-learning-java-must-read.html) : Get basics of Java
 - [Garbage collection (Java); Augmenting data str (video)](https://www.youtube.com/watch?v=StdfeXaKGEc&list=PL-XXv-cvA_iAlnI-BQr9hjqADPBtujFJd&index=25)
@@ -232,39 +232,39 @@ When learning CS there are some useful sites you must know to get always informe
 
 
 ## Learn AI
-- [Unsupervised Sentiment Neuron ](https://blog.openai.com/unsupervised-sentiment-neuron)
+- [Unsupervised Sentiment Neuron](https://blog.openai.com/unsupervised-sentiment-neuron)
 - [Robots that learn](https://blog.openai.com/robots-that-learn)
 - [grakn.ai](https://grakn.ai)
 
 ## Seminar , research writing , talks etc
-- [Advice on Research and Writing ](http://www.cs.cmu.edu/~mleone/how-to.html)
-- [Seminar and reports ](https://www.cse.iitb.ac.in/~ranade/communicationskills.html)
-- [PHD MS Articles ](http://www.cse.iitd.ac.in/~srsarangi/articles.html)
-- [Practical Tips for Talking at Usergroups and Conferences ](https://stephenhaunts.com/2015/10/02/practical-tips-for-talking-at-usergroups-and-conferences-part-1)
-- [ Giving presentation on software project to non-programmers ](https://stephenhaunts.com/2015/10/02/practical-tips-for-talking-at-usergroups-and-conferences-part-1)
+- [Advice on Research and Writing](http://www.cs.cmu.edu/~mleone/how-to.html)
+- [Seminar and reports](https://www.cse.iitb.ac.in/~ranade/communicationskills.html)
+- [PHD MS Articles](http://www.cse.iitd.ac.in/~srsarangi/articles.html)
+- [Practical Tips for Talking at Usergroups and Conferences](https://stephenhaunts.com/2015/10/02/practical-tips-for-talking-at-usergroups-and-conferences-part-1)
+- [Giving presentation on software project to non-programmers](https://stephenhaunts.com/2015/10/02/practical-tips-for-talking-at-usergroups-and-conferences-part-1)
 
 ## Everything in one place
 - [reddit.com/user/ashish2199/m/cs_student_subs](https://www.reddit.com/user/ashish2199/m/cs_student_subs) : a multisubreddit of all subreddits of topics related to computer science and programming.
 
 ## YouTube Channels
-- [Computerphile ](https://www.youtube.com/user/Computerphile/videos) : Must watch for every CS student
-- [ComputerHistory ](https://www.youtube.com/user/ComputerHistory/videos) : for those who like to know how we reached where we are.
-- [GoogleTechTalks ](https://www.youtube.com/user/GoogleTechTalks/videos) : videos on trending topics and cool stuff happening in the tech industry.
-- [Placement Grid ](https://www.youtube.com/user/PlacementGrid/videos) : Interview and campus placement experience
-- [Google Developers ](https://www.youtube.com/user/GoogleDevelopers/videos)
-- [Facebook Developers ](https://www.youtube.com/user/FacebookDevelopers/videos)
-- [O'Reilly ](https://www.youtube.com/user/OreillyMedia/videos) : interviews and talks of world's best technical writers.
-- [Java ](https://www.youtube.com/user/java/videos) : talks related to java
-- [JavaOne ](https://www.youtube.com/channel/UCdDhYMT2USoLdh4SZIsu_1g/videos) : Java Conference
-- [CppCon ](https://www.youtube.com/user/CppCon/videos?shelf_id=0&view=0&sort=dd) : C++ Conference
+- [Computerphile](https://www.youtube.com/user/Computerphile/videos) : Must watch for every CS student
+- [ComputerHistory](https://www.youtube.com/user/ComputerHistory/videos) : for those who like to know how we reached where we are.
+- [GoogleTechTalks](https://www.youtube.com/user/GoogleTechTalks/videos) : videos on trending topics and cool stuff happening in the tech industry.
+- [Placement Grid](https://www.youtube.com/user/PlacementGrid/videos) : Interview and campus placement experience
+- [Google Developers](https://www.youtube.com/user/GoogleDevelopers/videos)
+- [Facebook Developers](https://www.youtube.com/user/FacebookDevelopers/videos)
+- [O'Reilly](https://www.youtube.com/user/OreillyMedia/videos) : interviews and talks of world's best technical writers.
+- [Java](https://www.youtube.com/user/java/videos) : talks related to java
+- [JavaOne](https://www.youtube.com/channel/UCdDhYMT2USoLdh4SZIsu_1g/videos) : Java Conference
+- [CppCon](https://www.youtube.com/user/CppCon/videos?shelf_id=0&view=0&sort=dd) : C++ Conference
 - [C++Now (BoostCon)](https://www.youtube.com/channel/UC5e__RG9K3cHrPotPABnrwg) : C++Now (previously BoostCon) conference
-- [Meeting C++ YT Kanalseite ](https://www.youtube.com/user/MeetingCPP/videos) : Talks on C++
-- [ThinMatrix ](https://www.youtube.com/user/ThinMatrix/videos) : blogs and tutorials developer making a 3d game in Java using opengl
-- [yegor256 ](https://www.youtube.com/user/technoparkcorp/videos)
-- [Scott Meyers: Past Talks ](http://www.aristeia.com/presentations.html)
-- [thoughtbot  ](https://www.youtube.com/user/ThoughtbotVideo/videos) : talks on various topics
+- [Meeting C++ YT Kanalseite](https://www.youtube.com/user/MeetingCPP/videos) : Talks on C++
+- [ThinMatrix](https://www.youtube.com/user/ThinMatrix/videos) : blogs and tutorials developer making a 3d game in Java using opengl
+- [yegor256](https://www.youtube.com/user/technoparkcorp/videos)
+- [Scott Meyers: Past Talks](http://www.aristeia.com/presentations.html)
+- [thoughtbot](https://www.youtube.com/user/ThoughtbotVideo/videos) : talks on various topics
 - [code::dive conference](https://www.youtube.com/channel/UCU0Rt8VHO5-YNQXwIjkf-1g) : code::dive conference organized by NOKIA Wrocław Technology Center
-- [HowToBecomeTV ](https://www.youtube.com/user/HowToBecomeTV/videos) : contains good interviews of developers and people related to tech industry.
+- [HowToBecomeTV](https://www.youtube.com/user/HowToBecomeTV/videos) : contains good interviews of developers and people related to tech industry.
 - [Siraj Raval](https://www.youtube.com/channel/UCWN3xxRkmTPmbKwht9FuE5A) : Artificial Intelligence and deep learning tutorials videos
 - [Netflix UI Engineering](https://www.youtube.com/channel/UCGGRRqAjPm6sL3-WGBDnKJA/videos) : great videos to watch for web developers, mobile developers and those interested in some of Netflix's tech stack
 - [Coding Blocks](https://www.youtube.com/CodingBlocks) : Tutorials, how to's, tips and tricks
@@ -272,21 +272,21 @@ When learning CS there are some useful sites you must know to get always informe
 - [Fun Fun Function](https://www.youtube.com/c/mpjmevideos) : A weekly series from Mattias Petter Johansson on an assortment of programming topics, including some not directly related to coding.
 
 ## Good Articles
-- [Expectations of a Junior Developer ](http://blog.thefirehoseproject.com/posts/expectations-of-a-junior-developer)
-- [The Key To Accelerating Your Coding Skills ](http://blog.thefirehoseproject.com/posts/learn-to-code-and-be-self-reliant)
-- [A Software Developer’s Reading List ](https://stevewedig.com/2014/02/03/software-developers-reading-list) : Some good books and links in there.
-- [how-to-break-into-tech-job-hunting-and-interviews/ ](http://haseebq.com/how-to-break-into-tech-job-hunting-and-interviews)
-- [40 Keys Computer Science Concepts Explained In Layman’s Terms ](http://carlcheo.com/compsci)
+- [Expectations of a Junior Developer](http://blog.thefirehoseproject.com/posts/expectations-of-a-junior-developer)
+- [The Key To Accelerating Your Coding Skills](http://blog.thefirehoseproject.com/posts/learn-to-code-and-be-self-reliant)
+- [A Software Developer’s Reading List](https://stevewedig.com/2014/02/03/software-developers-reading-list) : Some good books and links in there.
+- [how-to-break-into-tech-job-hunting-and-interviews/](http://haseebq.com/how-to-break-into-tech-job-hunting-and-interviews)
+- [40 Keys Computer Science Concepts Explained In Layman’s Terms](http://carlcheo.com/compsci)
 - [What every programmer should know about memory, Part 1](https://lwn.net/Articles/250967)
 - [We are reinventing the retail industry through innovative technology](http://multithreaded.stitchfix.com)
-- [Unicode ](https://www.joelonsoftware.com/2003/10/08/the-absolute-minimum-every-software-developer-absolutely-positively-must-know-about-unicode-and-character-sets-no-excuses)
+- [Unicode](https://www.joelonsoftware.com/2003/10/08/the-absolute-minimum-every-software-developer-absolutely-positively-must-know-about-unicode-and-character-sets-no-excuses)
 - [What every programmer absolutely, positively needs to know about encodings and character sets to work with text](http://kunststube.net/encoding)
 - [List of algorithms](https://www.wikiwand.com/en/List_of_algorithms)
 - [Dive into the byte code](https://www.wikiwand.com/en/Java_bytecode)
-- [What every computer science major should know ](http://matt.might.net/articles/what-cs-majors-should-know)
+- [What every computer science major should know](http://matt.might.net/articles/what-cs-majors-should-know)
 - [Teach Yourself Computer Science](https://teachyourselfcs.com)
 - [Data Structure Map](https://fkcd.ca/b7d.svg)
-- [A Gentle Introduction To Graph Theory ](https://dev.to/vaidehijoshi/a-gentle-introduction-to-graph-theory)
+- [A Gentle Introduction To Graph Theory](https://dev.to/vaidehijoshi/a-gentle-introduction-to-graph-theory)
 - [Linux Inside](https://0xax.gitbooks.io/linux-insides/content/Booting/linux-bootstrap-1.html)
 - [A programmer friendly language that compiles to Lua.](http://moonscript.org)
 
@@ -305,44 +305,44 @@ When learning CS there are some useful sites you must know to get always informe
 ## Building a Simple Compiler/interpreter
 - [Resources for Amateur Compiler Writers](http://c9x.me/compile/bib)
 - [:snowman: Possibly the smallest compiler ever](https://github.com/thejameskyle/the-super-tiny-compiler)
-- [Writing My First Compiler ](https://dev.to/fcpauldiaz/writing-my-first-compiler)
+- [Writing My First Compiler](https://dev.to/fcpauldiaz/writing-my-first-compiler)
 - [Structure and Interpretation of Computer Programs](https://sarabander.github.io/sicp/html/index.xhtml)
--  [Let’s Build A Simple Interpreter. Part 1. ](https://ruslanspivak.com/lsbasi-part1)
+-  [Let’s Build A Simple Interpreter. Part 1.](https://ruslanspivak.com/lsbasi-part1)
 -  [Growing a compiler](http://www.cs.dartmouth.edu/~mckeeman/cs48/mxcom/gem/html/GrowingCompiler.html)
 
 ## Tutorials
 - [Subtle | Poor Man's CI](https://www.subtle.press/course/poor-mans-ci) : Learn how continuous integration platforms work under the hood, by building one of your own on top of git with Node.js
-- [Tutorialspoint ](http://www.tutorialspoint.com)
-- [W3Schools Online Web Tutorials ](http://www.w3schools.com)
-- [Open Data Structures ](http://opendatastructures.org) : Excellent resource for learning about DS and algos , provides code in various languages C++ , Java , pseudocode
-- [Data Structures and Algorithms by John Morris ](http://oopweb.com/Algorithms/Documents/PLDS210/VolumeFrames.html) : another good source with code and its analysis
-- [CMSI 281: Data Structures ](http://cs.lmu.edu/~ray/classes/dsa) : light weight introduction to DS
-- [How to Program in C++  ](http://cs.fit.edu/~mmahoney/cse2050/how2cpp.html) : Good resource for revising C++ topics and STL
-- [TopCoder Tutorials ](https://www.topcoder.com/community/data-science/data-science-tutorials)
-- [A Hacker's Guide to Git ](http://wildlyinaccurate.com/a-hackers-guide-to-git) : for those wanting to learn git with a solid foundation
-- [Git from the inside out ](http://maryrosecook.com/blog/post/git-from-the-inside-out)
+- [Tutorialspoint](http://www.tutorialspoint.com)
+- [W3Schools Online Web Tutorials](http://www.w3schools.com)
+- [Open Data Structures](http://opendatastructures.org) : Excellent resource for learning about DS and algos , provides code in various languages C++ , Java , pseudocode
+- [Data Structures and Algorithms by John Morris](http://oopweb.com/Algorithms/Documents/PLDS210/VolumeFrames.html) : another good source with code and its analysis
+- [CMSI 281: Data Structures](http://cs.lmu.edu/~ray/classes/dsa) : light weight introduction to DS
+- [How to Program in C++](http://cs.fit.edu/~mmahoney/cse2050/how2cpp.html) : Good resource for revising C++ topics and STL
+- [TopCoder Tutorials](https://www.topcoder.com/community/data-science/data-science-tutorials)
+- [A Hacker's Guide to Git](http://wildlyinaccurate.com/a-hackers-guide-to-git) : for those wanting to learn git with a solid foundation
+- [Git from the inside out](http://maryrosecook.com/blog/post/git-from-the-inside-out)
 - [Learn UNIX in 10 minutes](http://freeengineer.org/learnUNIXin10minutes.html)
 - [The Bash Guide](http://guide.bash.academy) : very good guide for learning the Bash Shell
-- [Linux Tutorial ](http://ryanstutorials.net/linuxtutorial) : good resource for learning Linux
-- [UNIX Tutorial - Introduction ](http://www.ee.surrey.ac.uk/Teaching/Unix/unixintro.html)
-- [Linux Tutorial for Beginners ](http://www.ee.surrey.ac.uk/Teaching/Unix)
-- [Learning the shell. ](http://linuxcommand.org/learning_the_shell.php)
+- [Linux Tutorial](http://ryanstutorials.net/linuxtutorial) : good resource for learning Linux
+- [UNIX Tutorial - Introduction](http://www.ee.surrey.ac.uk/Teaching/Unix/unixintro.html)
+- [Linux Tutorial for Beginners](http://www.ee.surrey.ac.uk/Teaching/Unix)
+- [Learning the shell.](http://linuxcommand.org/learning_the_shell.php)
 - [Dynamic programming - PrismoSkills](http://prismoskills.appspot.com/lessons/Dynamic_Programming/Chapter_01_-_Introduction.jsp) : very good resource if want to learn how to solve DP problems.
-- [Deep C  ](http://www.slideshare.net/olvemaudal/deep-c) : very good presentation on C language
-- [C programming language Frequently Asked Questions ](http://c-faq.com/index.html)
-- [OS Course Notes ](https://www.cs.uic.edu/~jbell/CourseNotes/OperatingSystems) : Chapter wise course notes according to Galvin's book
-- [SQL (Structured Query Language) in one page : SQL.SU ](http://www.cheat-sheets.org/sites/sql.su) : a very good SQL cheat sheet
-- [Introduction to C Programming ](http://www.le.ac.uk/users/rjm1/cotter/index.htm)
-- [MySQL Essentials ](http://www.techotopia.com/index.php/MySQL_Essentials)
-- [http://www.mysqltutorial.org/ ](http://www.mysqltutorial.org)
-- [Best Of - Gustavo Duarte  ](http://duartes.org/gustavo/blog/best-of) : contains articles on various topics
-- [Collecting all the cheat sheets ](http://overapi.com) : cheat sheets for lots of programming languages
-- [The Descent to C  ](http://www.chiark.greenend.org.uk/~sgtatham/cdescent) : for those moving to C from some higher programming language like java or python.
-- [VimTutor+ ](https://vimtutorplus.herokuapp.com/exercise/1) : learn VIM from browser itself
-- [HackerEarth Tutorials ](https://learn.hackerearth.com/tutorials) : Good resource for DS and Algos tutorial
-- [Linux Journey ](https://linuxjourney.com) : good site for learning linux
-- [C Programming ](http://www.cs.cf.ac.uk/Dave/C/CE.html)
-- [CS 2112/ENGRD 2112 Fall 2015 ](http://www.cs.cornell.edu/courses/cs2112/2015fa/lectures/index.html) : Good notes on data structures and algorithms.
+- [Deep C](http://www.slideshare.net/olvemaudal/deep-c) : very good presentation on C language
+- [C programming language Frequently Asked Questions](http://c-faq.com/index.html)
+- [OS Course Notes](https://www.cs.uic.edu/~jbell/CourseNotes/OperatingSystems) : Chapter wise course notes according to Galvin's book
+- [SQL (Structured Query Language) in one page : SQL.SU](http://www.cheat-sheets.org/sites/sql.su) : a very good SQL cheat sheet
+- [Introduction to C Programming](http://www.le.ac.uk/users/rjm1/cotter/index.htm)
+- [MySQL Essentials](http://www.techotopia.com/index.php/MySQL_Essentials)
+- [http://www.mysqltutorial.org/](http://www.mysqltutorial.org)
+- [Best Of - Gustavo Duarte](http://duartes.org/gustavo/blog/best-of) : contains articles on various topics
+- [Collecting all the cheat sheets](http://overapi.com) : cheat sheets for lots of programming languages
+- [The Descent to C](http://www.chiark.greenend.org.uk/~sgtatham/cdescent) : for those moving to C from some higher programming language like java or python.
+- [VimTutor+](https://vimtutorplus.herokuapp.com/exercise/1) : learn VIM from browser itself
+- [HackerEarth Tutorials](https://learn.hackerearth.com/tutorials) : Good resource for DS and Algos tutorial
+- [Linux Journey](https://linuxjourney.com) : good site for learning linux
+- [C Programming](http://www.cs.cf.ac.uk/Dave/C/CE.html)
+- [CS 2112/ENGRD 2112 Fall 2015](http://www.cs.cornell.edu/courses/cs2112/2015fa/lectures/index.html) : Good notes on data structures and algorithms.
 - [More about Github-flavored markdown](https://guides.github.com/features/mastering-markdown)
 - [The Unix Programming Environment](http://product.half.ebay.com/The-UNIX-Programming-Environment-by-Brian-W-Kernighan-and-Rob-Pike-1983-Other/54385&tg=info)
 - [The Linux Command Line: A Complete Introduction](https://www.amazon.com/dp/1593273894)
@@ -357,22 +357,22 @@ When learning CS there are some useful sites you must know to get always informe
 - [LiveEdu.tv](https://www.liveedu.tv) : screencast of people building application, websites, games, ect.
 
 ## What should a programmer know
-- [Programmer Competency Matrix  ](http://sijinjoseph.com/programmer-competency-matrix) : article for knowing what our level as a programmer is.
-- [GitHub.com Build software better, together  ](https://github.com) : Place to showcase your project and collaborate with others. (Must know Git in order to use it effectively)
+- [Programmer Competency Matrix](http://sijinjoseph.com/programmer-competency-matrix) : article for knowing what our level as a programmer is.
+- [GitHub.com Build software better, together](https://github.com) : Place to showcase your project and collaborate with others. (Must know Git in order to use it effectively)
 - [Gitlab offers free unlimited (private) repositories and unlimited collaborators](https://gitlab.com).
 
 ## Competitive programming
 - [WakaTime](https://wakatime.com) : leaderboards of coding metrics collected via editor plugins
-- [HackerRank ](http://hackerrank.com)
-- [Codeforces ](http://codeforces.com)
-- [topcoder ](http://topcoder.com)
-- [UVa Online Judge ](https://uva.onlinejudge.org) : hundreds of problems supporting multiple languages.
-- [HackerEarth - Programming challenges and Developer jobs ](http://hackerearth.com)
-- [CodeChef ](http://codechef.com)
-- [PKU ACM ICPC Practice problems ](http://poj.org/problemlist)
-- [Archived Problems - Project Euler ](https://projecteuler.net/archives)
-- [Google Code Jam Practice and ](https://code.google.com/codejam/contests.html) : past contest problems for practice
-- [Sphere Online Judge (SPOJ) ](http://www.spoj.com)
+- [HackerRank](http://hackerrank.com)
+- [Codeforces](http://codeforces.com)
+- [topcoder](http://topcoder.com)
+- [UVa Online Judge](https://uva.onlinejudge.org) : hundreds of problems supporting multiple languages.
+- [HackerEarth - Programming challenges and Developer jobs](http://hackerearth.com)
+- [CodeChef](http://codechef.com)
+- [PKU ACM ICPC Practice problems](http://poj.org/problemlist)
+- [Archived Problems - Project Euler](https://projecteuler.net/archives)
+- [Google Code Jam Practice and](https://code.google.com/codejam/contests.html) : past contest problems for practice
+- [Sphere Online Judge (SPOJ)](http://www.spoj.com)
 - [Art of Problem Solving](https://artofproblemsolving.com)
 - [Riddles.io AI Games](https://www.riddles.io) : Compete with your bot and dominate the leaderboards!
 - [Codingame](https://www.codingame.com) : Learn coding through games and challenges!
@@ -380,34 +380,34 @@ When learning CS there are some useful sites you must know to get always informe
 - [Codefights](https://codefights.com) : Test your coding skills
 
 ## Computer Books
-- [IT eBooks - Free Download - Big Library  ](http://it-ebooks.info) : website for downloading ebooks without any advertisement and instant downloads.
-- [github.com/vhf/free-programming-books ](https://github.com/vhf/free-programming-books/blob/master/free-programming-books.md) : More than 500 free ebooks on almost any language you can think of
-- [Computer Science Books Online ](http://www.sciencebooksonline.info/computer-science.html) : about 150 computer free ebooks
-- [Best books for GATE CSE ](http://gatecse.in/wiki/Best_books_for_CSE#Best_Books_for_GATE_in_CSE)
+- [IT eBooks - Free Download - Big Library](http://it-ebooks.info) : website for downloading ebooks without any advertisement and instant downloads.
+- [github.com/vhf/free-programming-books](https://github.com/vhf/free-programming-books/blob/master/free-programming-books.md) : More than 500 free ebooks on almost any language you can think of
+- [Computer Science Books Online](http://www.sciencebooksonline.info/computer-science.html) : about 150 computer free ebooks
+- [Best books for GATE CSE](http://gatecse.in/wiki/Best_books_for_CSE#Best_Books_for_GATE_in_CSE)
 - [https://cses.fi/book.html](https://cses.fi/book.html)
 - [Library Genesis](http://gen.lib.rus.ec) : Almost any ebook you can think of, including countless CS texts and manuals.
 
 ## Video Tutorials
-- [Tushar Roy ](https://www.youtube.com/user/tusharroy2525/videos) : Algorithm and Data structure tutorial by an Indian Youtuber.
-- [Derek Banas ](https://www.youtube.com/user/derekbanas/videos) : good quality tutorials
-- [thenewboston ](https://www.youtube.com/user/thenewboston/videos) : good but with too much talk as compared to actual content
-- [mycodeschool ](https://www.youtube.com/user/mycodeschool/videos) : Data structures and algorithms tutorials
-- [CodeGeek ](https://www.youtube.com/channel/UCJYhP1lceSUc1bg0LRBUvqA/videos)
-- [CodingMadeEasy  ](https://www.youtube.com/user/CodingMadeEasy/videos) : C++ tutorials
-- [XDA-University - Helping You Learn Android Development ](http://xda-university.com)
-- [DevTips ](https://www.youtube.com/user/DevTipsForDesigners/videos) : web dev tutorials
-- [codedamn  ](https://www.youtube.com/channel/UCJUmE61LxhbhudzUugHL2wQ/videos) : front end web dev tutorials
-- [Design and Analysis of Algorithms ](http://openclassroom.stanford.edu/MainFolder/CoursePage.php?course=IntroToAlgorithms)
-- [Vim Tutorial Videos - Flarfnoogins ](http://derekwyatt.org/vim/tutorials/index.html) : good video tutorial for learning vim
-- [CS1: Higher Computing - Richard Buckland UNSW ](https://www.youtube.com/playlist?list=PL6B940F08B9773B9F) : a very good introductory CS course
-- [Kathryn Hodge ](https://www.youtube.com/channel/UC4DwZ2VXM2KWtzHjVk9M_xg/videos) : Has good videos for beginners
+- [Tushar Roy](https://www.youtube.com/user/tusharroy2525/videos) : Algorithm and Data structure tutorial by an Indian Youtuber.
+- [Derek Banas](https://www.youtube.com/user/derekbanas/videos) : good quality tutorials
+- [thenewboston](https://www.youtube.com/user/thenewboston/videos) : good but with too much talk as compared to actual content
+- [mycodeschool](https://www.youtube.com/user/mycodeschool/videos) : Data structures and algorithms tutorials
+- [CodeGeek](https://www.youtube.com/channel/UCJYhP1lceSUc1bg0LRBUvqA/videos)
+- [CodingMadeEasy](https://www.youtube.com/user/CodingMadeEasy/videos) : C++ tutorials
+- [XDA-University - Helping You Learn Android Development](http://xda-university.com)
+- [DevTips](https://www.youtube.com/user/DevTipsForDesigners/videos) : web dev tutorials
+- [codedamn](https://www.youtube.com/channel/UCJUmE61LxhbhudzUugHL2wQ/videos) : front end web dev tutorials
+- [Design and Analysis of Algorithms](http://openclassroom.stanford.edu/MainFolder/CoursePage.php?course=IntroToAlgorithms)
+- [Vim Tutorial Videos - Flarfnoogins](http://derekwyatt.org/vim/tutorials/index.html) : good video tutorial for learning vim
+- [CS1: Higher Computing - Richard Buckland UNSW](https://www.youtube.com/playlist?list=PL6B940F08B9773B9F) : a very good introductory CS course
+- [Kathryn Hodge](https://www.youtube.com/channel/UC4DwZ2VXM2KWtzHjVk9M_xg/videos) : Has good videos for beginners
 
 ## Online Compiler and Sharing Code snippets
 - [CodePad](https://codepad.remoteinterview.io) : Code editor to try, test and run 25+ languages
 - [JSFiddle](https://jsfiddle.net) : Test your JavaScript, CSS, HTML or CoffeeScript with online code editor
-- [Ideone.com ](https://ideone.com)
-- [Pastebin.com ](http://pastebin.com)
-- [Godbolt.org ](https://godbolt.org): Excellent tool for exploring the assembly output of different compilers with and without optimization.
+- [Ideone.com](https://ideone.com)
+- [Pastebin.com](http://pastebin.com)
+- [Godbolt.org](https://godbolt.org): Excellent tool for exploring the assembly output of different compilers with and without optimization.
 
 ## Blogs of Developers
 - [Coding Horror](http://blog.codinghorror.com) : one the best coding blog
@@ -415,53 +415,53 @@ When learning CS there are some useful sites you must know to get always informe
 - [Armin Ronacher's Thoughts and Writings](http://lucumr.pocoo.org) : blog on Python and open source
 - [Eli Bendersky](http://eli.thegreenplace.net) : everything from Python to LLVM
 - [Joel on Software](http://joelonsoftware.com)
-- [ Stephen Haunts { Coding in the Trenches } ](https://stephenhaunts.com)
+- [Stephen Haunts { Coding in the Trenches }](https://stephenhaunts.com)
 - [Programming in the 21st Century](http://prog21.dadgum.com)
-- [Clean Coder Blog  ](http://blog.cleancoder.com) : blog of author of book "Clean Code"
+- [Clean Coder Blog](http://blog.cleancoder.com) : blog of author of book "Clean Code"
 - [Programming Blog](http://www.yegor256.com) : programming blog of Yegor Bugayenko
 - [CodeAhoy](https://codeahoy.com) : Blog on software and human factors. 100% Tested on Humans.
-- [http://stevehanov.ca/blog/ ](http://stevehanov.ca/blog)
-- [Geek Land ](https://avidullu.wordpress.com)
-- [Late Developer ](https://latedev.wordpress.com)
-- [IT Enthusiast ](http://rodiongork.tumblr.com)
-- [blog.might.net ](http://matt.might.net/articles)
-- [CSE Blog - quant, math, computer science puzzles ](http://www.cseblog.com)
+- [http://stevehanov.ca/blog/](http://stevehanov.ca/blog)
+- [Geek Land](https://avidullu.wordpress.com)
+- [Late Developer](https://latedev.wordpress.com)
+- [IT Enthusiast](http://rodiongork.tumblr.com)
+- [blog.might.net](http://matt.might.net/articles)
+- [CSE Blog - quant, math, computer science puzzles](http://www.cseblog.com)
 - [Small Programming Challenges and Puzzles](https://www.nayuki.io/category/programming)
-- [My Tech Interviews ](http://www.mytechinterviews.com)
-- [HackerEarth Blog ](http://blog.hackerearth.com)
-- [Algo-Geeks ](http://algo-geeks.blogspot.in)
-- [CoderGears Blog Insights from ](http://www.codergears.com/Blog) : the CoderGears Team
-- [Runhe Tian Coding Practice ](https://tianrunhe.wordpress.com)
-- [Paul Graham Essays ](http://www.paulgraham.com/articles.html)
-- [Dan Dreams of Coding ](http://dandreamsofcoding.com)
-- [Antonio081014's Algorithms Codes ](http://code.antonio081014.com)
+- [My Tech Interviews](http://www.mytechinterviews.com)
+- [HackerEarth Blog](http://blog.hackerearth.com)
+- [Algo-Geeks](http://algo-geeks.blogspot.in)
+- [CoderGears Blog Insights from](http://www.codergears.com/Blog) : the CoderGears Team
+- [Runhe Tian Coding Practice](https://tianrunhe.wordpress.com)
+- [Paul Graham Essays](http://www.paulgraham.com/articles.html)
+- [Dan Dreams of Coding](http://dandreamsofcoding.com)
+- [Antonio081014's Algorithms Codes](http://code.antonio081014.com)
 - [Math ∩ Programming](http://jeremykun.com)
-- [Takipi Blog ](http://blog.takipi.com) : mainly focuses on Java and JVM languages
-- [Coding Geek - A blog about IT, programming and Java ](http://coding-geek.com)
-- [Daedtech.com ](http://www.daedtech.com) : Stories about software
-- [Archives — Ask a Manager ](http://www.askamanager.org/archives) : HR related stuff
+- [Takipi Blog](http://blog.takipi.com) : mainly focuses on Java and JVM languages
+- [Coding Geek - A blog about IT, programming and Java](http://coding-geek.com)
+- [Daedtech.com](http://www.daedtech.com) : Stories about software
+- [Archives — Ask a Manager](http://www.askamanager.org/archives) : HR related stuff
 
 ## For improving your English
-- [Quia - English ](https://www.quia.com/shared/english)
+- [Quia - English](https://www.quia.com/shared/english)
 - [Punctuation and Capitalization Rules](http://www.grammarbook.com/english_rules.asp)
 - [Guide to Grammar and Writing](http://grammar.ccc.commnet.edu/grammar)
-- [Purdue University Online Writing Lab (OWL) ](https://owl.english.purdue.edu)
+- [Purdue University Online Writing Lab (OWL)](https://owl.english.purdue.edu)
 - [Englishclub.com/learn-english](https://www.englishclub.com/learn-english.htm)
 
 ## When you get bored from CS related stuff
 
 - [r/ProgrammerHumor](https://www.reddit.com/r/ProgrammerHumor) : Subreddit dedicated to exactly what it sounds like
 - [Guide to Grammar and Writing](http://grammar.ccc.commnet.edu/grammar) for those who want to improve their english language skills
-- [Vsauce ](https://www.youtube.com/user/Vsauce/videos) : The best youtube channel
-- [TED ](https://www.youtube.com/user/TEDtalksDirector/videos) : Great talks about technology, entertainment, and design
-- [CrashCourse ](https://www.youtube.com/user/crashcourse/videos) : small courses on various subjects
-- [National Geographic ](https://www.youtube.com/user/NationalGeographic/videos) : High volume of high quality content from all over the world
+- [Vsauce](https://www.youtube.com/user/Vsauce/videos) : The best youtube channel
+- [TED](https://www.youtube.com/user/TEDtalksDirector/videos) : Great talks about technology, entertainment, and design
+- [CrashCourse](https://www.youtube.com/user/crashcourse/videos) : small courses on various subjects
+- [National Geographic](https://www.youtube.com/user/NationalGeographic/videos) : High volume of high quality content from all over the world
 - [Barcroft TV](https://www.youtube.com/user/barcroftmedia/featured) : Daily short documentaries about the incredible variety of people that make up the world
-- [ColdFusion ](https://www.youtube.com/user/coldfustion/videos) : Past, present, and future of technology
-- [SmarterEveryDay ](https://www.youtube.com/user/destinws2/videos) : Lots of amazing scientific information about the world around us, usually captured with a high-speed camera
-- [SciShow ](https://www.youtube.com/user/scishow/videos) : Answers to interesting questions that you've always wondered about
+- [ColdFusion](https://www.youtube.com/user/coldfustion/videos) : Past, present, and future of technology
+- [SmarterEveryDay](https://www.youtube.com/user/destinws2/videos) : Lots of amazing scientific information about the world around us, usually captured with a high-speed camera
+- [SciShow](https://www.youtube.com/user/scishow/videos) : Answers to interesting questions that you've always wondered about
 - [Big Think](https://www.youtube.com/user/bigthink/videos) : Expert driven, actionable, educational content, featuring experts ranging from Bill Clinton to Bill Nye
-- [Every Frame a Painting ](https://www.youtube.com/user/everyframeapainting/videos) : High quality analysis of films and filmmaking
+- [Every Frame a Painting](https://www.youtube.com/user/everyframeapainting/videos) : High quality analysis of films and filmmaking
 - [TestTube News](https://www.youtube.com/user/TestTubeNetwork/videos) : Interesting information about news from around the world
 - [Reddit the front page of the internet](http://reddit.com) : Where free time goes to die
 

--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ When learning CS there are some useful sites you must know to get always informe
 <li><a href="#when-you-get-bored-from-cs-related-stuff">When you get bored from CS related stuff</a></li>
 </ul>
 
-# When you get stuck
+## When you get stuck
    * [Stack Overflow](http://stackoverflow.com/) : subscribe to their weekly newsletter and any other topic which you find interesting
    * [Quora](https://www.quora.com/) : A place to share knowledge and better understand the world:
    * [Learn Anything](https://learn-anything.xyz/) : Community curated knowledge graph of best paths for learning anything
 
-# News
+## News
    * [Hacker News](https://news.ycombinator.com/) : news aggregator for programmers where civility is king, try a newsletter to get top news to your inbox:
    * [Hacker Newsletter](http://www.hackernewsletter.com/) : curated by hand, delivered weekly
    * [Hacker News Digest](https://hndigest.com/) : curated automatically, delivered as frequently as you want
@@ -58,7 +58,7 @@ When learning CS there are some useful sites you must know to get always informe
    * [AlternativeTo](https://alternativeto.net) : Crowdsourced software recommendations
    * [Better Dev Links](https://betterdev.link) : Weekly links to help you become a better developer
 
-# Coding practice for beginners
+## Coding practice for beginners
    * [freeCodeCamp](https://www.freecodecamp.com/) : Learn to code and build projects for nonprofits. Build your full stack web development portfolio today
    * [Reddit.com/r/dailyprogrammer](http://www.reddit.com/r/dailyprogrammer) : interesting programming challenges where you can learn from looking at other's code , even if you are not able to solve code you can look at how others solved.
    * [Programming by Doing](http://programmingbydoing.com/) : very good site for those who want to start with absolute basics
@@ -70,13 +70,13 @@ When learning CS there are some useful sites you must know to get always informe
    * [Cave of programming](https://caveofprogramming.com/) : Learn to program, Upgrade your skills.
    * [Codeacademy](https://www.codecademy.com/) : Learn to code interactively, for free.
 
-# For those who want to start a small project but can't find the ideas
+## For those who want to start a small project but can't find the ideas
    * [martyr2s-mega-project-ideas-list](http://www.dreamincode.net/forums/topic/78802-martyr2s-mega-project-ideas-list/) : contains about 125 project ideas from beginner to intermediate level.
    * [karan/Projects](https://github.com/karan/Projects) : a large collection of small projects for beginners with
    * [Wrong "big projects" for beginners](http://rodiongork.tumblr.com/post/108155476418/wrong-big-projects-for-beginners) : How to choose where to start
    * [vicky002/1000-Projects](https://github.com/vicky002/1000_Projects) : Mega List of practical projects that one can solve in any programming language!
 
-# General Coding advice
+## General Coding advice
    * [Things I Wish Someone Had Told Me When I Was Learning How to Code — Free Code Camp](https://medium.freecodecamp.com/things-i-wish-someone-had-told-me-when-i-was-learning-how-to-code-565fc9dcb329#.y5wbd3pj6)
    * [Lessons From A Lifetime Of Being A Programmer](http://thecodist.com/article/lessons_from_a_lifetime_of_being_a_programmer)
    * [Principles of Good Programming](http://www.artima.com/weblogs/viewpost.jsp?thread=331531)
@@ -89,7 +89,7 @@ When learning CS there are some useful sites you must know to get always informe
    * [Software design pattern](https://en.wikipedia.org/wiki/Software_design_pattern) : The entire collection of Design Patterns.
    * [Design Patterns](https://sourcemaking.com/design_patterns) : Design Patterns explained in detail with examples.
 
-# Coding Style
+## Coding Style
    * [CS 106B Coding Style Guide](http://stanford.edu/class/archive/cs/cs106b/cs106b.1158/styleguide.shtml) : must see for those who create spaghetti
    * [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html)
    * [Airbnb JS Style Guide](https://github.com/airbnb/javascript) : A mostly reasonable approach to JavaScript
@@ -102,9 +102,9 @@ When learning CS there are some useful sites you must know to get always informe
    * [Directory of CS Courses (many with online lectures)](https://github.com/prakhar1989/awesome-courses)
    * [Angular 1 Style Guide](https://github.com/johnpapa/angular-styleguide/tree/master/a1) : Officially endorsed style guide by John Pappa
    
-# General Tools
+## General Tools
 
-# Interview Preparation
+### Interview Preparation
   * [GeeksforGeeks | A computer science portal for geeks](http://www.geeksforgeeks.org/) : also subscribe to their feeds to get links to their new articles.
   * [A site for technical interview questions, brain teasers, puzzles, quizzles](http://www.techinterview.org/) : whatever the heck those are) and other things that make you think!
   * [Problems | LeetCode OJ ](https://leetcode.com/problemset/algorithms/) : Coding practice for interviews
@@ -164,7 +164,7 @@ When learning CS there are some useful sites you must know to get always informe
   * [ChiperSoft/InterviewThis](https://github.com/ChiperSoft/InterviewThis) : questions to ask during on a interview to know more about the company.
   * [SQL interview questions](https://www.jitbit.com/news/181-jitbits-sql-interview-questions/) : great SQL test
 
-# Documentaries
+## Documentaries
   * Machine that Changed the World - a very good documentary about history of computers
       * [Part 1: Giant Brains ](http://www.youtube.com/watch?v=rcR74y61xZk)
       * [Part 2: Inventing the Future](https://www.youtube.com/watch?v=0iPiYxjsYKk)
@@ -186,7 +186,7 @@ When learning CS there are some useful sites you must know to get always informe
   * [Ask Me Anything: Gayle Laakmann McDowell (author of Cracking the Coding Interview)](https://www.youtube.com/watch?v=1fqxMuPmGak)
 
 
-# MOOCs for learning something new
+## MOOCs for learning something new
   * [Class Central](https://www.class-central.com) : a directory of 100,000+ student reviews of thousands of MOOCs.
   * [NPTEL Vidoes COMP_SCI_ENGG ](https://onlinecourses.nptel.ac.in/explorer/search?category=COMP_SCI_ENGG)
   * [Coursera.org](http://coursera.org/)
@@ -201,7 +201,7 @@ When learning CS there are some useful sites you must know to get always informe
   * [Computer Science Resources ](https://docs.google.com/spreadsheets/d/1BD8BJJUNaX63m2QmySWMGDp71nx4W4MyyiIBlfMoN3Q/htmlview?sle=true#) : list of MOOCs for autodidacts
   * [https://github.com/prakhar1989/awesome-courses/blob/master/README.md ](https://github.com/prakhar1989/awesome-courses/blob/master/README.md) : collection of CS courses on Internet
 
-# Sites related to your preferred programming language (For me Java)
+## Sites related to your preferred programming language (For me Java)
   * [Java Revisited ](http://javarevisited.blogspot.in/) : good for learning about Java Language and interview preparation.
   * [The Java™ Tutorials  ](https://docs.oracle.com/javase/tutorial/): The best tutorials for Java.
   * [Java Corner at Artima.com ](http://www.artima.com/java/index.html)
@@ -231,22 +231,22 @@ When learning CS there are some useful sites you must know to get always informe
 
 
 
-# Learn AI
+## Learn AI
  * [Unsupervised Sentiment Neuron ](https://blog.openai.com/unsupervised-sentiment-neuron/)
  * [Robots that learn](https://blog.openai.com/robots-that-learn/)
  * [grakn.ai](https://grakn.ai/)
 
-# Seminar , research writing , talks etc
+## Seminar , research writing , talks etc
   * [Advice on Research and Writing ](http://www.cs.cmu.edu/~mleone/how-to.html)
   * [Seminar and reports ](https://www.cse.iitb.ac.in/~ranade/communicationskills.html)
   * [PHD MS Articles ](http://www.cse.iitd.ac.in/~srsarangi/articles.html)
   * [Practical Tips for Talking at Usergroups and Conferences ](https://stephenhaunts.com/2015/10/02/practical-tips-for-talking-at-usergroups-and-conferences-part-1/)
   * [ Giving presentation on software project to non-programmers ](https://stephenhaunts.com/2015/10/02/practical-tips-for-talking-at-usergroups-and-conferences-part-1/)
 
-# Everything in one place
+## Everything in one place
   * [reddit.com/user/ashish2199/m/cs_student_subs](https://www.reddit.com/user/ashish2199/m/cs_student_subs) : a multisubreddit of all subreddits of topics related to computer science and programming.
 
-# YouTube Channels
+## YouTube Channels
   * [Computerphile ](https://www.youtube.com/user/Computerphile/videos) : Must watch for every CS student
   * [ComputerHistory ](https://www.youtube.com/user/ComputerHistory/videos) : for those who like to know how we reached where we are.
   * [GoogleTechTalks ](https://www.youtube.com/user/GoogleTechTalks/videos) : videos on trending topics and cool stuff happening in the tech industry.
@@ -271,7 +271,7 @@ When learning CS there are some useful sites you must know to get always informe
   * [Codely tv](https://www.youtube.com/UC9IKtxn9AIGelnYmwYr0Lxw) : Interviews, tips and tricks
   * [Fun Fun Function](https://www.youtube.com/c/mpjmevideos) : A weekly series from Mattias Petter Johansson on an assortment of programming topics, including some not directly related to coding.
 
-# Good Articles
+## Good Articles
   * [Expectations of a Junior Developer ](http://blog.thefirehoseproject.com/posts/expectations-of-a-junior-developer/)
   * [The Key To Accelerating Your Coding Skills ](http://blog.thefirehoseproject.com/posts/learn-to-code-and-be-self-reliant/)
   * [A Software Developer’s Reading List ](https://stevewedig.com/2014/02/03/software-developers-reading-list/) : Some good books and links in there.
@@ -290,7 +290,7 @@ When learning CS there are some useful sites you must know to get always informe
   * [Linux Inside](https://0xax.gitbooks.io/linux-insides/content/Booting/linux-bootstrap-1.html)
   * [A programmer friendly language that compiles to Lua.](http://moonscript.org/)
 
-# Podcasts
+## Podcasts
  * [Coding Blocks - Learning principles, patterns and better practices on the go](http://www.codingblocks.net/)
  * [MS Dev Show](http://msdevshow.com/)
  * [The Cynical Developer](http://cynicaldeveloper.com/)
@@ -302,7 +302,7 @@ When learning CS there are some useful sites you must know to get always informe
  * [Full Stack Radio](http://www.fullstackradio.com/) : Everything from product design and user experience to unit testing and system administration. 
  * [Software Engineering Daily](https://softwareengineeringdaily.com/) : A daily technical interview about software topics
 
-# Building a Simple Compiler/interpreter
+## Building a Simple Compiler/interpreter
  * [Resources for Amateur Compiler Writers](http://c9x.me/compile/bib/)
  * [:snowman: Possibly the smallest compiler ever](https://github.com/thejameskyle/the-super-tiny-compiler)
  * [Writing My First Compiler ](https://dev.to/fcpauldiaz/writing-my-first-compiler)
@@ -310,7 +310,7 @@ When learning CS there are some useful sites you must know to get always informe
  *  [Let’s Build A Simple Interpreter. Part 1. ](https://ruslanspivak.com/lsbasi-part1/)
  *  [Growing a compiler](http://www.cs.dartmouth.edu/~mckeeman/cs48/mxcom/gem/html/GrowingCompiler.html)
 
-# Tutorials
+## Tutorials
   * [Subtle | Poor Man's CI](https://www.subtle.press/course/poor-mans-ci/) : Learn how continuous integration platforms work under the hood, by building one of your own on top of git with Node.js
   * [Tutorialspoint ](http://www.tutorialspoint.com/)
   * [W3Schools Online Web Tutorials ](http://www.w3schools.com/)
@@ -353,15 +353,15 @@ When learning CS there are some useful sites you must know to get always informe
   * [Programming, Web Development, and DevOps news, tutorials and tools for beginners to experts](https://dzone.com/)
 
 
-# Watch others code
+## Watch others code
   * [LiveEdu.tv](https://www.liveedu.tv/) : screencast of people building application, websites, games, ect.
 
-# What should a programmer know
+## What should a programmer know
   * [Programmer Competency Matrix  ](http://sijinjoseph.com/programmer-competency-matrix/) : article for knowing what our level as a programmer is.
   * [GitHub.com Build software better, together  ](https://github.com/) : Place to showcase your project and collaborate with others. (Must know Git in order to use it effectively)
   * [Gitlab offers free unlimited (private) repositories and unlimited collaborators](https://gitlab.com).
 
-# Competitive programming
+## Competitive programming
   * [WakaTime](https://wakatime.com/) : leaderboards of coding metrics collected via editor plugins
   * [HackerRank ](http://hackerrank.com/)
   * [Codeforces ](http://codeforces.com/)
@@ -379,7 +379,7 @@ When learning CS there are some useful sites you must know to get always informe
   * [Codewars](https://www.codewars.com/) : Rank up by completing code kata
   * [Codefights](https://codefights.com/) : Test your coding skills
 
-# Computer Books
+## Computer Books
   * [IT eBooks - Free Download - Big Library  ](http://it-ebooks.info/) : website for downloading ebooks without any advertisement and instant downloads.
   * [github.com/vhf/free-programming-books ](https://github.com/vhf/free-programming-books/blob/master/free-programming-books.md) : More than 500 free ebooks on almost any language you can think of
   * [Computer Science Books Online ](http://www.sciencebooksonline.info/computer-science.html) : about 150 computer free ebooks
@@ -387,7 +387,7 @@ When learning CS there are some useful sites you must know to get always informe
   * [https://cses.fi/book.html](https://cses.fi/book.html)
   * [Library Genesis](http://gen.lib.rus.ec) : Almost any ebook you can think of, including countless CS texts and manuals.
 
-# Video Tutorials
+## Video Tutorials
   * [Tushar Roy ](https://www.youtube.com/user/tusharroy2525/videos) : Algorithm and Data structure tutorial by an Indian Youtuber.
   * [Derek Banas ](https://www.youtube.com/user/derekbanas/videos) : good quality tutorials
   * [thenewboston ](https://www.youtube.com/user/thenewboston/videos) : good but with too much talk as compared to actual content
@@ -402,14 +402,14 @@ When learning CS there are some useful sites you must know to get always informe
   * [CS1: Higher Computing - Richard Buckland UNSW ](https://www.youtube.com/playlist?list=PL6B940F08B9773B9F) : a very good introductory CS course
   * [Kathryn Hodge ](https://www.youtube.com/channel/UC4DwZ2VXM2KWtzHjVk9M_xg/videos) : Has good videos for beginners
 
-# Online Compiler and Sharing Code snippets
+## Online Compiler and Sharing Code snippets
   * [CodePad](https://codepad.remoteinterview.io/) : Code editor to try, test and run 25+ languages
   * [JSFiddle](https://jsfiddle.net/) : Test your JavaScript, CSS, HTML or CoffeeScript with online code editor
   * [Ideone.com ](https://ideone.com/)
   * [Pastebin.com ](http://pastebin.com/)
   * [Godbolt.org ](https://godbolt.org/): Excellent tool for exploring the assembly output of different compilers with and without optimization.
 
-# Blogs of Developers
+## Blogs of Developers
   * [Coding Horror](http://blog.codinghorror.com/) : one the best coding blog
   * [WildMl](http://www.wildml.com/) : A blog for machine learning.
   * [Armin Ronacher's Thoughts and Writings](http://lucumr.pocoo.org/) : blog on Python and open source
@@ -441,14 +441,14 @@ When learning CS there are some useful sites you must know to get always informe
   * [Daedtech.com ](http://www.daedtech.com/) : Stories about software
   * [Archives — Ask a Manager ](http://www.askamanager.org/archives) : HR related stuff
 
-# For improving your English
+## For improving your English
   * [Quia - English ](https://www.quia.com/shared/english/)
   * [Punctuation and Capitalization Rules](http://www.grammarbook.com/english_rules.asp)
   * [Guide to Grammar and Writing](http://grammar.ccc.commnet.edu/grammar/)
   * [Purdue University Online Writing Lab (OWL) ](https://owl.english.purdue.edu/)
   * [Englishclub.com/learn-english](https://www.englishclub.com/learn-english.htm)
 
-# When you get bored from CS related stuff
+## When you get bored from CS related stuff
 
   * [r/ProgrammerHumor](https://www.reddit.com/r/ProgrammerHumor/) : Subreddit dedicated to exactly what it sounds like
   * [Guide to Grammar and Writing](http://grammar.ccc.commnet.edu/grammar/) for those who want to improve their english language skills

--- a/README.md
+++ b/README.md
@@ -200,8 +200,6 @@ When learning CS there are some useful sites you must know to get always informe
 - [prakhar1989/awesome-CS-courses](https://github.com/prakhar1989/awesome-courses/blob/master/README.md) : List containing large amount of CS courses
 - [Computer Science Resources](https://docs.google.com/spreadsheets/d/1BD8BJJUNaX63m2QmySWMGDp71nx4W4MyyiIBlfMoN3Q/htmlview?sle=true#) : list of MOOCs for autodidacts
 
-<!--duplicate-->
-<!--- [https://github.com/prakhar1989/awesome-courses/blob/master/README.md](https://github.com/prakhar1989/awesome-courses/blob/master/README.md) : collection of CS courses on Internet-->
 
 ## Sites related to your preferred programming language (For me Java)
 - [Java Revisited](http://javarevisited.blogspot.in) : good for learning about Java Language and interview preparation.
@@ -470,7 +468,5 @@ When learning CS there are some useful sites you must know to get always informe
 - [TestTube News](https://www.youtube.com/user/TestTubeNetwork/videos) : Interesting information about news from around the world
 - [Reddit the front page of the internet](https://www.reddit.com) : Where free time goes to die
 
-<!--duplicte for improving your english-->
-<!--- [Guide to Grammar and Writing](http://grammar.ccc.commnet.edu/grammar) for those who want to improve their english language skills-->
 
   **Maintained with :heart: by sdmg15 & al**

--- a/README.md
+++ b/README.md
@@ -155,7 +155,6 @@ When learning CS there are some useful sites you must know to get always informe
 - [How to Break Into the Tech Industry - a Guide to Job Hunting and Tech Interviews](http://haseebq.com/how-to-break-into-tech-job-hunting-and-interviews/)
 - [Freshers Interviews](http://placementsindia.blogspot.in)
 - [C PUZZLES, Some interesting C problems](http://www.gowrikumar.com/c/index.php)
-- [A site for technical interview questions, brain teasers, puzzles, quizzles (whatever the heck those are) and other things that make you think!](https://www.techinterview.org)
 - [wu :: riddles(hard)](https://www.ocf.berkeley.edu/~wwu/riddles/hard.shtml) : logic puzzles and riddles
 - [github.com/odino/interviews](https://github.com/odino/interviews) : list of important questions for interview
 - [svozniuk/java-interviews](https://github.com/svozniuk/java-interviews) : Java interview questions
@@ -284,13 +283,6 @@ When learning CS there are some useful sites you must know to get always informe
 - [A Gentle Introduction To Graph Theory](https://dev.to/vaidehijoshi/a-gentle-introduction-to-graph-theory)
 - [Linux Inside](https://0xax.gitbooks.io/linux-insides/content/Booting/linux-bootstrap-1.html)
 - [A programmer friendly language that compiles to Lua.](http://moonscript.org)
-
-<!--duplicate on Interview Documentaries-->
-<!--- [Teach Yourself Computer Science](https://teachyourselfcs.com)-->
-<!--duplicate on general coding advice-->
-<!--- [What every computer science major should know](http://matt.might.net/articles/what-cs-majors-should-know)-->
-<!--duplicate on Interview Preparation-->
-<!--- [how-to-break-into-tech-job-hunting-and-interviews/](http://haseebq.com/how-to-break-into-tech-job-hunting-and-interviews)-->
 
 ## Podcasts
 - [Coding Blocks - Learning principles, patterns and better practices on the go](http://www.codingblocks.net)
@@ -422,7 +414,7 @@ When learning CS there are some useful sites you must know to get always informe
 - [Clean Coder Blog](http://blog.cleancoder.com) : blog of author of book "Clean Code"
 - [Programming Blog](http://www.yegor256.com) : programming blog of Yegor Bugayenko
 - [CodeAhoy](https://codeahoy.com) : Blog on software and human factors. 100% Tested on Humans.
-- [http://stevehanov.ca/blog/](http://stevehanov.ca/blog/)
+- [stevehanov.ca](http://stevehanov.ca/blog/)
 - [Geek Land](https://avidullu.wordpress.com)
 - [Late Developer](https://latedev.wordpress.com)
 - [IT Enthusiast](http://rodiongork.tumblr.com)

--- a/README.md
+++ b/README.md
@@ -166,11 +166,11 @@ When learning CS there are some useful sites you must know to get always informe
 
 ## Documentaries
 - Machine that Changed the World - a very good documentary about history of computers
-      * [Part 1: Giant Brains](http://www.youtube.com/watch?v=rcR74y61xZk)
-      * [Part 2: Inventing the Future](https://www.youtube.com/watch?v=0iPiYxjsYKk)
-      * [Part 3: The Paperback Computer](https://www.youtube.com/watch?v=d7DKVfOXr54)
-      * [Part 4: The Thinking Machine](https://www.youtube.com/watch?v=enWWlx7-t0k)
-      * [Part 5: The World at Your Fingertips](https://www.youtube.com/watch?v=fLLXiP7diEo)
+  - [Part 1: Giant Brains](http://www.youtube.com/watch?v=rcR74y61xZk)
+  - [Part 2: Inventing the Future](https://www.youtube.com/watch?v=0iPiYxjsYKk)
+  - [Part 3: The Paperback Computer](https://www.youtube.com/watch?v=d7DKVfOXr54)
+  - [Part 4: The Thinking Machine](https://www.youtube.com/watch?v=enWWlx7-t0k)
+  - [Part 5: The World at Your Fingertips](https://www.youtube.com/watch?v=fLLXiP7diEo)
 - [Triumph of the Nerds](https://www.youtube.com/playlist?list=PLn-Y3vvQbmHO5WUcBdIWqiUfNawhC1cn3) : Play-list
 - [Project Code Rush - The Beginnings of Netscape / Mozilla Documentary](https://www.youtube.com/watch?v=a-49a_CjH0M)
 - [The Code: Story of Linux documentary](https://www.youtube.com/watch?v=XMm0HsmOTFI)


### PR DESCRIPTION
here is the fixed version based on bot suggestion.

- first adding several urls which fail awesome-bot link check. possible reason
  - it require trailing slash, but awesome-lint require trailing slash to be removed
  - may not connect everytime (e.g. projecteuler.net/archives)
  - redirect everytime it is checked (e.g. medium.freecodecamp.com)
- also delete duplicate entry or merge it if possible
- delete removed url such as codely tv

e:i haven't found the answer for trailing slash on awesome-lint vs awesome-bot. awesome-lint from @sindresorhus have config.js example on the repo, but i have no idea how to use it