### PR TITLE
Feature/fix travis test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ before_script:
   - npm install --global awesome-lint
 script:
   - awesome-lint
-  - awesome_bot README.md --white-list www.cubrid.org,medium.freecodecamp.com,learn.hackerearth.com,wildlyinaccurate.com,projecteuler.net,www.coursera.org,www.topcoder.com,www.codechef.com,www.joelonsoftware.com,regex101.com,bikeshed.fm
+  - awesome_bot README.md --white-list www.cubrid.org,medium.freecodecamp.com,learn.hackerearth.com,wildlyinaccurate.com,projecteuler.net,www.coursera.org,www.topcoder.com,www.codechef.com,www.joelonsoftware.com,regex101.com,bikeshed.fm,www.quora.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ before_script:
   - npm install --global awesome-lint
 script:
   - awesome-lint
-  - awesome_bot README.md --white-list www.cubrid.org,medium.freecodecamp.com,learn.hackerearth.com,wildlyinaccurate.com,projecteuler.net,www.coursera.org,www.topcoder.com,www.codechef.com,www.joelonsoftware.com
+  - awesome_bot README.md --white-list www.cubrid.org,medium.freecodecamp.com,learn.hackerearth.com,wildlyinaccurate.com,projecteuler.net,www.coursera.org,www.topcoder.com,www.codechef.com,www.joelonsoftware.com,regex101.com,bikeshed.fm

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ When learning CS there are some useful sites you must know to get always informe
    
    
 ## General Tools
- - [regex101](http://regex101.com/) : Online regex tester and debugger: PHP, PCRE, Python, Golang and JavaScript
+- [regex101](https://regex101.com/) : Online regex tester and debugger: PHP, PCRE, Python, Golang and JavaScript
 
 ## Interview Preparation
 - [GeeksforGeeks | A computer science portal for geeks](http://www.geeksforgeeks.org) : also subscribe to their feeds to get links to their new articles.
@@ -312,7 +312,7 @@ When learning CS there are some useful sites you must know to get always informe
 - [Developer Tea](https://spec.fm/podcasts/developer-tea) : A podcast for developers designed to fit inside your tea break.
 - [Full Stack Radio](http://www.fullstackradio.com) : Everything from product design and user experience to unit testing and system administration. 
 - [Software Engineering Daily](https://softwareengineeringdaily.com) : A daily technical interview about software topics
-- [The Bike Shed](http://bikeshed.fm/) : Guests discuss their development experience and challenges with Ruby, Rails, JavaScript, and others.
+- [The Bike Shed](http://bikeshed.fm) : Guests discuss their development experience and challenges with Ruby, Rails, JavaScript, and others.
 
 
 ## Building a Simple Compiler/interpreter

--- a/README.md
+++ b/README.md
@@ -353,7 +353,6 @@ When learning CS there are some useful sites you must know to get always informe
 - [Collecting all the cheat sheets](http://overapi.com) : cheat sheets for lots of programming languages
 - [The Descent to C](https://www.chiark.greenend.org.uk/~sgtatham/cdescent/) : for those moving to C from some higher programming language like java or python.
 - [VimTutor+](https://vimtutorplus.herokuapp.com/exercise/1) : learn VIM from browser itself
-- [HackerEarth Tutorials](https://www.hackerearth.com) : Good resource for DS and Algos tutorial
 - [Linux Journey](https://linuxjourney.com) : good site for learning linux
 - [C Programming](http://users.cs.cf.ac.uk/Dave.Marshall/C/CE.html)
 - [CS 2112/ENGRD 2112 Fall 2015](http://www.cs.cornell.edu/courses/cs2112/2015fa/lectures/index.html) : Good notes on data structures and algorithms.

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ When learning CS there are some useful sites you must know to get always informe
    
    
 ## General Tools
-- [regex101](https://regex101.com/) : Online regex tester and debugger: PHP, PCRE, Python, Golang and JavaScript
+- [regex101](https://regex101.com) : Online regex tester and debugger: PHP, PCRE, Python, Golang and JavaScript
 
 ## Interview Preparation
 - [GeeksforGeeks | A computer science portal for geeks](http://www.geeksforgeeks.org) : also subscribe to their feeds to get links to their new articles.


### PR DESCRIPTION
fix based on suggestion from bot.

another problem exist, which is the trailing slash/awesome-lint config problem. so regex101 and bikeshed will be added to whitelist (again)

hackerearth entry on tutorial section is removed because of duplicate.

the actual link to this is https://learn.hackerearth.com/tutorials/ based on this (https://github.com/sdmg15/Best-websites-a-programmer-should-visit/blob/e4b49c34dead96d25c3fbaa1cc124b7028b70392/README.md) but it will redirect to hackerearth front page. if it is changed to frontpage then it will be marked as duplicate.

e: also add quora to whitelist because it may raise 429 http error code