### PR TITLE
Add new software development website.

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [10-ways-to-be-a-better-developer](https://stephenhaunts.files.wordpress.com/2014/04/10-ways-to-be-a-better-developer.png) : Ways to become a better dev!
 - [Code Review Best Practices](https://www.kevinlondon.com/2015/05/05/code-review-best-practices.html) : Kevin London's blog
 - [Design Patterns](https://sourcemaking.com/design_patterns) : Design Patterns explained in detail with examples.
+- [Develop for Performance] (http://developforperformance.com) : High-performance computing techniques for software architects and developers
 - [How to become a programmer, or the art of Googling well](https://okepi.wordpress.com/2014/08/21/how-to-become-a-programmer-or-the-art-of-googling-well/) : How to become a programmer, or the art of Googling well
 - [JS Project Guidelines](https://github.com/wearehive/project-guidelines) : A set of best practices for JavaScript projects.
 - [Learn to Code With Me](https://learntocodewith.me) : A comprehensive site resource by Laurence Bradford for developers who aims to build a career in the tech world


### PR DESCRIPTION
This change seeks to add Develop for Performance, a website dedicated to high-performance computing, for software architects and developers.  While there are many online resources focused on the academic / theoretical aspects of high-performance computing, there are relatively few oriented toward practical software development.

Currently this website features just content that I've authored.  Anyone wishing to write for Develop for Performance is free to contact me, though I'd like to ensure that new content is of a quality, style. and depth fairly similar to that of the existing content.  There's example code, sometimes specific to C++ and Windows, though the concepts are covered with a range of environments and platforms in mind.

Some info about my background is available here:
http://www.developforperformance.com/AboutDevelopForPerformance.html