### PR TITLE
Fix Watch Others Code urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,8 +512,8 @@ When learning CS, there are some useful sites you must know to get always inform
 - [Java tutorial](https://hackr.io/tutorials/learn-java) : A programming community & a great place to find the best online programming courses and tutorials.
 
 ## Watch others code
-- [LiveEdu.tv](https://www.liveedu.tv) : screencast of people building application, websites, games, etc.
-- [Twitch.tv](https://www.twitch.tv/communities/programming) : The programming community of twitch.
+- [Education Ecosystem](https://www.education-ecosystem.com) : screencast of people building application, websites, games, etc.
+- [Twitch.tv](https://www.twitch.tv/directory/game/Science%20%26%20Technology) : The programming community of twitch.
 
 
 ## What should a programmer know


### PR DESCRIPTION
LiveEdu.tv is now Education Ecosystem. The currently listed url redirects. I'm not familiar with the old or new website, hopefully it's still a good resource.

Twitch.tv has removed its "communities" feature that the current url links to. I've replaced it with a url to the Science & Technology category. This is often used by streamers who are programming.

Thanks!