### PR TITLE
Add Classpert under the MOOcs list

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ When learning CS, there are some useful sites you must know to get always inform
 
 ## MOOCs for learning something new
 - [Class Central](https://www.class-central.com) : a directory of 100,000+ student reviews of thousands of MOOCs.
+- [Classpert](https://classpert.com) : a website that gathers MOOCs and online courses from several providers, focusing on computer science and data science courses.
 - [Computer Science Resources](https://docs.google.com/spreadsheets/d/1BD8BJJUNaX63m2QmySWMGDp71nx4W4MyyiIBlfMoN3Q/htmlview?sle=true#) : list of MOOCs for autodidacts
 - [Coursera.org](https://www.coursera.org) : Take the world's best courses, online.
 - [CS50](https://www.youtube.com/user/cs50tv/videos) : A set of goods tutorials from cs50


### PR DESCRIPTION
Recently, we launched https://classpert.com - a free search engine for online courses. Our main focus is on Computer Science and Data Science courses (we have indexed over 150k courses so far). I'm adding it under the MOOCs list, as I believe it might be a valuable resource for programmers.