### PR TITLE
(fix) link of programming-language-for-me-java

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [prakhar1989/awesome-CS-courses](https://github.com/prakhar1989/awesome-courses/blob/master/README.md) : List containing large amount of CS courses
 
 
-## Sites related to your preferred programming language (For me C++)
+## Sites related to your preferred programming language (For me Java)
 - [Best books for learning java must read](https://javahungry.blogspot.com/2014/02/best-books-for-learning-java-must-read.html) : Get basics of Java
 - [Bjarne Stroustrup's C++ Style and Technique FAQ](http://www.stroustrup.com/bs_faq2.html) : The C++ FAQ
 - [Bjarne Stroustrup's FAQ](http://www.stroustrup.com/bs_faq.html) : The C++ FAQ


### PR DESCRIPTION
The link of your "Sites related to your preferred programming language is broken (Java in the summary and C++ in the details which result of a broken link). I set up Java in both :) Hopefully its your favorite one :-)