### PR TITLE
Change JSFiddle to include all the Fiddles

### DIFF
--- a/README.md
+++ b/README.md
@@ -686,7 +686,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [Codesandbox.io](https://codesandbox.io) : CodeSandbox makes it easier to create, share, and reuse React projects with others.
 - [Godbolt.org](https://godbolt.org) : Excellent tool for exploring the assembly output of different compilers with and without optimization.
 - [Ideone.com](https://ideone.com) : online compiler and debugging tool for more than 60 programming languages
-- [JSFiddle](https://jsfiddle.net) : Test your JavaScript, CSS, HTML or CoffeeScript with online code editor
+- [Fiddles.io](https://fiddles.io) : Online code editing and and sharing for many different languages and environments.
 - [JSBin](https://jsbin.com/) : Front end playground, Output is not framed, so it allows you to share those snippets that will break inside an iframe.
 - [Judge0 IDE](https://ide.judge0.com) : Online compiler with 40+ interpreters and compilers.
 - [Pastebin.com](https://pastebin.com) : Pastebin can store texts like code, notes, and snippets online for a set time which can be shared instantly.


### PR DESCRIPTION
While JSFiddle is the original that we all know and love, many more have come along.  This should be updated to include the list of all available Fiddles.