### PR TITLE
Add "Security engineering" book

### DIFF
--- a/README.md
+++ b/README.md
@@ -651,6 +651,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [Data Science course](https://jakevdp.github.io/PythonDataScienceHandbook/) : Python Data Science Handbook
 - [Goal Kicker](https://goalkicker.com) : Programming Notes for Professionals books
 - [The GraphQL Guide](https://graphql.guide) : The complete guide to GraphQL, the new REST ✨
+- [Security Engineering](https://www.cl.cam.ac.uk/~rja14/book.html) : A Guide to Building Dependable Distributed Systems
 
 <div align="right">
   <b><a href="#index">↥ Back To Top</a></b>


### PR DESCRIPTION
This PR adds the e-book "Security engineering" (https://www.cl.cam.ac.uk/~rja14/book.html) to the list of computer books.