### PR TITLE
added link to troyhunt.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -736,6 +736,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [Takipi Blog](http://blog.takipi.com) : mainly focuses on Java and JVM languages
 - [XDA - Android Developer Forum](https://forum.xda-developers.com) : Android Open Source Developers Forum
 - [The Net Ninja](https://www.thenetninja.co.uk/): Web development tutorials
+- [Troy Hunt](https://www.troyhunt.com/): Security-Focussed blog by Troy Hunt, creator of Have I Been Pwned
 
 <div align="right">
   <b><a href="#index">↥ Back To Top</a></b>


### PR DESCRIPTION
I noticed that there is a section for developer blogs, but troyhunt.com, which I personally think is a high quality security blog, was missing; so I went ahead and fixed that :)