### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ node_js:
 rvm:
   - 2.2
 env:
-  - TRAVIS_NODE_VERSION="7"
+  - TRAVIS_NODE_VERSION="12"
 install:
-  - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
+  - nvm install $TRAVIS_NODE_VERSION
   - npm install
 before_script:
   - gem install awesome_bot
@@ -14,4 +14,3 @@ before_script:
 script:
   - awesome-lint
   - awesome_bot README.md --white-list $(paste -d, -s white_listed_sites.txt) --allow-ssl --allow-redirect
-


### PR DESCRIPTION
# What I changed
- Changed Node.js version from version 7 to Node.js 12 since there is no reason and no incompatibility that justifies using an old and long unsupported node version
- Removed manual pull of nvm since nvm has been included in travis environments for a while now