### PR TITLE
Add dashdash.io and ss64.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,8 @@ When learning CS, there are some useful sites you must know to get always inform
 - [API Documentation](http://devdocs.io) : A one-place well-known API Documentation with a searchable interface
 - [Baeldung](https://www.baeldung.com) : Step-by-step guides for Spring, rest, Java, security, persistence, Jackson, HTTP client-side and Kotlin
 - [cheat.sh](https://github.com/chubin/cheat.sh) : `curl cheat.sh` — the only cheat sheet you need — instant answers on programming questions with `curl`
+- [dashdash.io](https://dashdash.io/) : A visually appealing and searchable collection of unix tools manpages
+- [ss64](https://ss64.com/) : A large collection of command line references for multiple platforms
 - [Developer Roadmaps](https://roadmap.sh/) : Step by step guides and paths to learn different tools or technologies
 - [DevURLs](https://devurls.com/) : Developer news aggregator
 - [MDN Web Docs](https://developer.mozilla.org/en-US/) : A place with all the documentation of the web standards


### PR DESCRIPTION
I've added [dasdash.io](https://dashdash.io/) and [ss64.com](https://ss64.com/) to the `Everything in one place` section.