### PR TITLE
Add DevDocs in General Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [CodePad](https://codepad.remoteinterview.io/DDCUYLAEYS) : Quickly Conduct Coding Interviews and Phone Screen Interviews.
 - [CodePen](https://codepen.io) : Front End Developer Playground & Code Editor in the Browser
 - [Crontab Guru](https://crontab.guru/) : Quick and simple editor for cron schedule expressions
+- [DevDocs](https://devdocs.io/): Website that combines multiple API documentations in a fast, organized, and searchable interface.
 - [Devicons](http://vorillaz.github.io/devicons/#/main) : Cheatsheet for devs icons
 - [Diagrams.net](https://app.diagrams.net/) : Drawing tools to make design and uml easily. Old draw.io
 - [FreeFor.Dev](https://free-for.dev/#/) : A huge list of free resources and tools


### PR DESCRIPTION
Add [DevDocs](https://devdocs.io/) in General Tools section.
DevDocs is a website which aggregates multiple API specs (even programming languages docs) in a simple and searchable interface.