### PR TITLE
Adding Websites to learn Cyber Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,6 @@ When learning CS, there are some useful sites you must know to get always inform
 - [MOOC.fi](http://mooc.fi/english.html) : Free online courses from the University of Helsinki
 - [NPTEL](http://nptel.ac.in) : Free online courses by IIT with certificates
 - [prakhar1989/awesome-CS-courses](https://github.com/prakhar1989/awesome-courses/blob/master/README.md) : List containing large amount of CS courses
-- [Pluralsight](https://www.pluralsight.com) : An online learning and workforce development platform that helps businesses and individuals adjust to changing technology.
 
 <div align="right">
   <b><a href="#index">↥ Back To Top</a></b>


### PR DESCRIPTION
1. Cybrary (https://www.cybrary.it/)
2. SecurityTube (http://www.securitytube.net/)
3. Harvard/EDX (https://www.edx.org/course/subject/computer-science)
4. SANS Cyber Aces (http://www.cyberaces.org/courses/)
5. Digitokawn (https://digitokawn.com/trainings/)