### PR TITLE
Delete broken Quora links

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,7 +529,6 @@ When learning CS, there are some useful sites you must know to get always inform
 - [A Software Developer’s Reading List](https://stevewedig.com/2014/02/03/software-developers-reading-list/) : Some good books and links in there.
 - [Code a TCP/IP stack](http://www.saminiir.com/lets-code-tcp-ip-stack-5-tcp-retransmission/) : Let's code a TCP/IP stack, 5: TCP Retransmission
 - [Codewords.recurse](https://codewords.recurse.com/issues/four/the-language-of-choice) : The language of choice
-- [Data structure and Algorithms](https://techiedelight.quora.com/500-Data-Structures-and-Algorithms-practice-problems-and-their-solutions) : List of some algorithms and data structures with their solutions.
 - [Dive into the byte code](https://www.wikiwand.com/en/Java_bytecode)
 - [Expectations of a Junior Developer](http://blog.thefirehoseproject.com/posts/expectations-of-a-junior-developer/)
 - [Getting Started with MongoDB – An Introduction](https://studio3t.com/knowledge-base/articles/mongodb-getting-started/)


### PR DESCRIPTION
### Description
The answers and articles from quora are missing or otherwise gone.

### Changes
- I deleted the following links:
1. https://techiedelight.quora.com/500-Data-Structures-and-Algorithms-practice-problems-and-their-solutions : question was deleted
2. 

### Why quora
I also searched for the links on the Web Archive, but found out, that quora blocks web scrapers like the Web Archive 
![quora](https://user-images.githubusercontent.com/67599521/139603271-2b7bc23a-4278-480f-8e8b-1e303cf94c8a.png)
![quora_web-archive](https://user-images.githubusercontent.com/67599521/139603283-234a53b1-69e0-4be1-8abf-e2f80da2d956.png)
source: https://waxy.org/2018/12/why-you-should-never-ever-use-quora/

### Remarks
The first was also mentioned in the pr #1083
But this pr makes few changes, which should be easy to be verified and approved