### PR TITLE
Add programmingbooks.dev to Computer Books section

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,6 +717,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [Goal Kicker](https://goalkicker.com) : Programming Notes for Professionals books
 - [The GraphQL Guide](https://graphql.guide) : The complete guide to GraphQL, the new REST ✨
 - [Eloquent JavaScript](https://eloquentjavascript.net/) : A book about JavaScript, programming, and the wonders of the digital.
+- [programmingbooks.dev](https://www.programmingbooks.dev) : An Ordered and Curated Reading List for Software Craftsmanship Growth.
 
 <div align="right">
   <b><a href="#index">↥ Back To Top</a></b>


### PR DESCRIPTION
I have added programmingbooks.dev to the Computer Books section. programmingbooks.dev aims to help people read more programming books without getting overwhelmed. I hope you like it.