### PR TITLE
Add new programming book site

### DIFF
--- a/README.md
+++ b/README.md
@@ -722,7 +722,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [The GraphQL Guide](https://graphql.guide) : The complete guide to GraphQL, the new REST ✨
 - [Eloquent JavaScript](https://eloquentjavascript.net/) : A book about JavaScript, programming, and the wonders of the digital.
 - [programmingbooks.dev](https://www.programmingbooks.dev) : An Ordered and Curated Reading List for Software Craftsmanship Growth.
-
+- [goalkicker.com](https://www.goalkicker.com) : A curated list of free programming books for professionals and beginners, compiled from the StackkOverflow documentation
 <div align="right">
   <b><a href="#index">↥ Back To Top</a></b>
 </div>


### PR DESCRIPTION
Hello! I've added https://goalkicker.com to the list of sites. It provides books/notes compiled from the SO documentation. 
