### PR TITLE
Fix checklist format on PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -7,6 +7,6 @@
 
 <!--- Please mark all options that apply to your case. -->
 
-[ ] My change follows the [Contributing Guidelines](./CONTRIBUTING.md)
-[ ] I have added only one new link to the list.
-[ ] I have sorted the link alphabetically under the related section.
+- [ ] My change follows the [Contributing Guidelines](./CONTRIBUTING.md)
+- [ ] I have added only one new link to the list.
+- [ ] I have sorted the link alphabetically under the related section.


### PR DESCRIPTION
## Description

The checklist format was missing the list prefix, which was previously omitted as per my own mistake. It should work properly per GitHub standards from now on. Apologies!

Relates to #1388 

## Checklist

- [x] My change follows the [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] I have added only one new link to the list.
- [ ] I have sorted the link alphabetically under the related section.
