### PR TITLE
Adds PC World to Magazine Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ When learning CS, there are some useful sites you must know to get always inform
 ## Magazines
 - [MIT Technology Review](https://www.technologyreview.com/magazine/) : MIT's tech review magazine.
 - [Nautilus](http://nautil.us) : NewYorker for tech.
+- [PC World](https://www.pcworld.com/) : Tech advice and reviews.
 - [LWN](https://lwn.net) : Weekly news coverage of opensource technologies, programming, etc. ( Originally Linux Weekly News).
 
 <div align="right">


### PR DESCRIPTION
## Description
This PR adds PC World Magazine under the Magazine section.

<!--- Please include a summary of the changes and the related issue. -->
<!--- If your changes closes an issue ticket, please refer it as: Fixes #<number> -->

## Checklist

<!--- Please mark all options that apply to your case. -->

[X] My change follows the [Contributing Guidelines](./CONTRIBUTING.md)
[X] I have added only one new link to the list.
[X] I have sorted the link alphabetically under the related section.
