### PR TITLE
Added CompSciLib to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ When learning CS, there are some useful sites you must know to get always inform
 ## General Tools
 - [CoderPad](https://coderpad.io) : Quickly Conduct Coding Interviews and Phone Screen Interviews.
 - [CodePen](https://codepen.io) : Front End Developer Playground & Code Editor in the Browser
+- [CompSciLib](https://www.compscilib.com/) : Computer Science theory education with interactive tools, learning tutorials, and practice questions.
 - [Crontab Guru](https://crontab.guru/) : Quick and simple editor for cron schedule expressions
 - [Devicons](http://vorillaz.github.io/devicons/#/main) : Cheatsheet for devs icons
 - [Diagrams.net](https://app.diagrams.net/) : Drawing tools to make design and uml easily. Old draw.io


### PR DESCRIPTION
## Summary of your changes

### Description

Added a link to the CompSciLib website under general tools. CompSciLib is a platform that helps students with their Computer Science theory and math classes.

### Checklist

<!--- Please mark all options that apply to your case. -->

- [ ] My change follows the [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] I have added only one new link to the list.
- [ ] I have checked that the link that I added does NOT exist in the project already.
- [ ] I have sorted the link alphabetically under the related section.
