### PR TITLE
Add a useful mock interview website for interview preparation

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [kimberli/interviews](https://github.com/kimberli/interviews) : study sheet for Interview
 - [LeetCode](https://leetcode.com/) : A new way to learn.here you can prepare for your interview.
 - [Learnersbucket](https://learnersbucket.com): Data Structures and Algorithms in Javascript.
+- [Meetapro](https://meetapro.com/?utm_source=bwapsvgithub): An Airbnb-style mock interview platform with experienced FAANG engineers with low cost.
 - [Mission-peace/interview problems](https://github.com/mission-peace/interview/wiki) : A large collection of coding interview problems
 - [NeetCode](https://neetcode.io): Prepare topic wise coding questions which are most frequently asked in MAANG companies. 
 - [Pramp/A free on demand interview practice platform for Software Engineers](https://www.pramp.com/ref/gt1) : Practice coding interviews with real peers


### PR DESCRIPTION
Envision Meetapro as the Airbnb for mock interviews and career coaching. It connects job seekers with seasoned FAANG interviewers who provide invaluable feedback, getting you ready for real-life interviews. Numerous job seekers have already reaped the benefits of this platform.

What makes Meetapro stand out?

Affordability: The average cost per session is significantly lower compared to other platforms.
Expert interviewers: Veterans from FAANG and top-tier companies bring years of experience, offering priceless feedback that truly makes a difference.
Direct communication: Job seekers can directly message interviewers to address any questions or concerns, such as experience sharing or rescheduling, ensuring better preparation for both parties.
All-in-one tools: Meetapro equips you with the essential tools for an effective interview session, including recording options for post-session review.

## Summary of your changes

### Description

<!--- Please include a summary of the changes and the related issue. -->
<!--- If your changes closes an issue ticket, please refer it as: Fixes #<number> -->

### Checklist

<!--- Please mark all options that apply to your case. -->

- [ ] My change follows the [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] I have added only one new link to the list.
- [ ] I have checked that the link that I added does NOT exist in the project already.
- [ ] I have sorted the link alphabetically under the related section.
