### PR TITLE
add Svix Play to General Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [Svgator](https://www.svgator.com/): Animate svg graphically. Its like a video editor but for svg. 
 - [Webhook.site](https://webhook.site/): Useful tool for test and debug webhooks.
 - [kandi](https://kandi.openweaver.com/): Jumpstart Application Development by finding the right Open Source resource
+- [Svix Play](https://play.svix.com/): Webhook tester & debugger. Test webhooks directly from your test suite.
 
 
 <div align="right">


### PR DESCRIPTION
## Summary of your changes

Add Svix Play to general tools.

### Description

Svix Play is a webhook tester & debugger with an API that lets you test webhooks directly from your test suite.

### Checklist

<!--- Please mark all options that apply to your case. -->

- [x] My change follows the [Contributing Guidelines](./CONTRIBUTING.md)
- [x] I have added only one new link to the list.
- [x] I have checked that the link that I added does NOT exist in the project already.
- [x] I have sorted the link alphabetically under the related section.
