### PR TITLE
Added Ethereum Bootcamp link under CryptoCurrency Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [Blockchain demo](https://blockchaindemo.io/) : A visual demo of Blockchain technology
 - [Build a blockchain in Python](https://hackernoon.com/learn-blockchains-by-building-one-117428612f46) : Learn Blockchains by Building One
 - [Coin demo](https://coindemo.io/) : CryptoCurrency demo
+- [Ethereum Developer Bootcamp](https://university.alchemy.com/overview/ethereum) : 7-week intermediate-level bootcamp to learn and create an Ethereum project
 - [GitCoin](https://gitcoin.co) : Gitcoin is the easiest way to monetize or incentivize work in Open Source Software.
 - [Learn About Bitcoin and Lightning Protocol](https://chaincode.gitbook.io/seminars/): Complete 4 weeks seminar ciricullum for learning about Bitcoin.
 - [Learn Me A Bitcoin](https://learnmeabitcoin.com/): Bitcoin, Cryptocurrencies and Blockchain explained in plain English


### PR DESCRIPTION
## Added Ethereum Developer Bootcamp resource link from Alchemy University

### Description

<!--- Please include a summary of the changes and the related issue. -->
<!--- If your changes closes an issue ticket, please refer it as: Fixes #<number> -->

- Updated README.md to contain the clickable link to the Ethereum Developer Bootcamp course offered for free by Alchemy University.
- Added the link under the CryptoCurrency section and organized it alphabetically.
- Fixes #1741 

### Checklist

<!--- Please mark all options that apply to your case. -->

- [x] My change follows the [Contributing Guidelines](./CONTRIBUTING.md)
- [x] I have added only one new link to the list.
- [x] I have checked that the link that I added does NOT exist in the project already.
- [x] I have sorted the link alphabetically under the related section.
