### PR TITLE
FAANGPath Resume template Link in Interview Preparation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [CS9: Problem-Solving for the CS Technical Interview](http://web.stanford.edu/class/cs9/)
 - [Delightful Puzzles](http://gurmeet.net/puzzles/)
 - [Determining the big-O runtimes of these different loops?](https://stackoverflow.com/questions/11094330/determining-the-big-o-runtimes-of-these-different-loops) : really good stackoverflow question that covers basics of calculating runtime complexity.
+- [FAANGPath Resume template](https://faangpath.com/template/) : Maximize your chances to get your resume in the hands on HR/HM.
 - [five-essential-phone-screen-questions - steveyegge2](https://sites.google.com/site/steveyegge2/five-essential-phone-screen-questions)
 - [Freshers Interviews](http://placementsindia.blogspot.com)
 - [Gainlo](http://www.gainlo.co/#!/) : Mock interview from professionals 


### PR DESCRIPTION
## Summary of your changes
Added a resume template link which help make a ATS friendly resume.

### Description

Added this resume template (FAANGPath) in Interview Preparation Section. Resumes are important for appearing in Interviews and I see no such template was provided in this Repo. FAANGPath is built in Openleaf which is known for its good parsing.

Fixes #1761 
### Checklist

- [x] My change follows the [Contributing Guidelines](./CONTRIBUTING.md)
- [x] I have added only one new link to the list.
- [x] I have checked that the link that I added does NOT exist in the project already.
- [x] I have sorted the link alphabetically under the related section.
