### PR TITLE
Adding a 4 day week job board

### DIFF
--- a/README.md
+++ b/README.md
@@ -951,6 +951,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [Linkedin jobs](https://www.linkedin.com/jobs) : A very nice research tool for programming jobs
 - [GermanTech Jobs](https://germantechjobs.de/) : Dedicated job board for tech roles in Germany - with salary brackets
 - [We Work Remotely](https://weworkremotely.com/) : The largest remote work community in the world.
+- [OkJob](https://okjob.io/) : 4 day week job board.
 
 <div align="right">
   <b><a href="#index">↥ Back To Top</a></b>


### PR DESCRIPTION
Adding a 4 day week job board (https://okjob.io/) to the mix.