### PR TITLE
Fixed broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [Interview Archives - Java Honk](http://javahonk.com/category/interview/)
 - [Interview Cake](https://www.interviewcake.com/) : Free and Paid course options offering high quality technical interview practice. 
 - [Job Interview: How to Ace a Job Interview/The Art of Manliness](http://www.artofmanliness.com/2012/08/06/how-to-ace-a-job-interview/)
-- [Job interviews News, Videos, Reviews and Gossip - Lifehacker](https://lifehacker.com/tag/job-interviews)
+- [Job interviews News, Videos, Reviews and Gossip - Lifehacker](https://lifehacker.com/search?s=job%20interviews/)
 - [Job Interview Questions and Best Answers](https://www.thebalance.com/job-interview-questions-and-answers-2061204)
 - [kimberli/interviews](https://github.com/kimberli/interviews) : study sheet for Interview
 - [LeetCode](https://leetcode.com/) : A new way to learn.here you can prepare for your interview.


### PR DESCRIPTION
## Summary of your changes
fixes: #1869
### Description

<!--- Please include a summary of the changes and the related issue. -->
<!--- If your changes closes an issue ticket, please refer it as: Fixes #<number> -->
- There is a broken link in the Interview Preparation section by the name: [Job interviews News, Videos, Reviews and Gossip - Lifehacker](https://lifehacker.com/tag/job-interviews)
- It means that the page has been removed.
- Upon going through the homepage, I came across the search button (accessible by the hamburger button on the top-right)
![image](https://github.com/sdmg15/Best-websites-a-programmer-should-visit/assets/108081278/b12ca53a-c43b-461d-9e75-53a86159abbf)
- When I searched for job interviews in the search bar, all the articles related to job interview (preparation, tips, reviews, etc..) were displayed.
![image](https://github.com/sdmg15/Best-websites-a-programmer-should-visit/assets/108081278/abf2c186-4c0e-4e90-b4a6-a3ee537853b2)
- So, I've fixed the broken link by adding the new link: [Job interviews News, Videos, Reviews and Gossip - Lifehacker](https://lifehacker.com/search?s=job%20interviews/)

### Checklist

<!--- Please mark all options that apply to your case. -->

- [x] My change follows the [Contributing Guidelines](./CONTRIBUTING.md)
- [x] I have added only one new link to the list.
- [x] I have checked that the link that I added does NOT exist in the project already.
- [x] I have sorted the link alphabetically under the related section.
