### PR TITLE
Add Bing Pros

### DIFF
--- a/README.md
+++ b/README.md
@@ -929,7 +929,8 @@ When learning CS, there are some useful sites you must know to get always inform
 ## Jobs
 - [AngelList](https://angel.co/) : AngelList is a 
     website for startups, angel investors, and job-seekers 
-    looking to work at startups. 
+    looking to work at startups.
+- [Bing Pros](https://www.bing.com/pros/onboarding?utmsource=fbrep&mkt=en-us) : A gig service platform that connects Bing Search users to providers who want higher profit for their services.
 - [CareerBuilder](https://hiring.careerbuilder.com) : CareerBuilder is one of the largest job boards, providing job listings, resume posting, and career advice and resources to job seekers.
 - [Dice](https://www.dice.com) : Dice is the leading site for tech job seekers.
     You can search by company, job title, keyword, employment type, and location.


### PR DESCRIPTION
## Summary of your changes
Add Bing Pros.
### Description
Bing Pros is a new gig service platform that connects Bing Search users to providers who want higher profit for their services.
<!--- Please include a summary of the changes and the related issue. -->
<!--- If your changes closes an issue ticket, please refer it as: Fixes #<number> -->

### Checklist

<!--- Please mark all options that apply to your case. -->

- [x] My change follows the [Contributing Guidelines](./CONTRIBUTING.md)
- [x] I have added only one new link to the list.
- [x] I have checked that the link that I added does NOT exist in the project already.
- [x] I have sorted the link alphabetically under the related section.
