### PR TITLE
Removed broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,7 +422,6 @@ When learning CS, there are some useful sites you must know to get always inform
 - [Understanding JVM Internals](http://www.cubrid.org/blog/understanding-jvm-internals) : Understanding JVM Internals
 - [what-is-garbage-collection](https://downloads.plumbr.io/Plumbr%20Handbook%20Java%20Garbage%20Collection.pdf) : Demystify the garbage collection
 - [JavaWorld](https://www.javaworld.com) : Welcome to Javaworld
-- [XyzWs Java FAQs](http://www.xyzws.com/javafaq/page/1) : large collection of java interview questions
 - [JavatPoint](https://www.javatpoint.com/java-tutorial) : Best website to get a basic Java programming tutorial
 - [The Rust Programming Language Book](https://doc.rust-lang.org/book/title-page.html) : Explains the Rust programming language
 - [Rust Cookbook](https://rust-lang-nursery.github.io/rust-cookbook/intro.html#cookin-with-rust) : Quickly get an overview of the capabilities of the Rust crate ecosystem


### PR DESCRIPTION
## Summary of your changes
Fixes #1891 
### Description
- There is dead link in the "<i>Sites related to your preferred programming language (For me C++)</i>" section:
    - [XyzWs Java FAQs](http://www.xyzws.com/javafaq/page/1) : large collection of java interview questions
- The link is dead and the site (xyzws.com) is unreachable.
- The last snapshot in the Wayback Machine ([Internet Archive](https://web.archive.org/web/20220616092928/http://www.xyzws.com/z0f76a1d14fd21a8fb5fd0d03e0fdc3d3cedae52f?wsidchk=24212038)) was on June 16, 2022 where the site is not reachable.
![image](https://github.com/sdmg15/Best-websites-a-programmer-should-visit/assets/108081278/680ec0bb-0a0f-4b75-82d8-f024883fc352)
- It must be removed.
<!--- Please include a summary of the changes and the related issue. -->
<!--- If your changes closes an issue ticket, please refer it as: Fixes #<number> -->

### Checklist

<!--- Please mark all options that apply to your case. -->

- [x] My change follows the [Contributing Guidelines](./CONTRIBUTING.md)
- [x] I have added only one new link to the list.
- [x] I have checked that the link that I added does NOT exist in the project already.
- [x] I have sorted the link alphabetically under the related section.
