### PR TITLE
Fix broken link in Good Articles Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,7 +569,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [Unicode](https://www.joelonsoftware.com/2003/10/08/the-absolute-minimum-every-software-developer-absolutely-positively-must-know-about-unicode-and-character-sets-no-excuses/)
 - [We are reinventing the retail industry through innovative technology](http://multithreaded.stitchfix.com)
 - [What every programmer absolutely, positively needs to know about encodings and character sets to work with text](http://kunststube.net/encoding/)
-- [What every programmer should know about memory - PDF](http://futuretech.blinkenlights.nl/misc/cpumemory.pdf)
+- [What every programmer should know about memory - PDF](https://www.akkadia.org/drepper/cpumemory.pdf)
 - [qotoqot - improving-focus](https://qotoqot.com/blog/improving-focus/) : How I got to 200 productive hours a month
 - [Pixel Beat - Unix](http://www.pixelbeat.org/docs/unix-parallel-tools.html) : Parallel processing with Unix tools
 - [Learning Vim](https://hackernoon.com/learning-vim-what-i-wish-i-knew-b5dca186bef7) : What I Wish I Knew


### PR DESCRIPTION
## Summary of your changes
Fixes #1897 
### Description
- There is a broken link in the __"Good Articles"__ section:
    - [What every programmer should know about memory - PDF](http://futuretech.blinkenlights.nl/misc/cpumemory.pdf)
- The link is broken and is not reachable.
- Al alternative, working link that points to the article/document is given here:
    - [What every programmer should know about memory - PDF](https://www.akkadia.org/drepper/cpumemory.pdf)
<!--- Please include a summary of the changes and the related issue. -->
<!--- If your changes closes an issue ticket, please refer it as: Fixes #<number> -->

### Checklist

<!--- Please mark all options that apply to your case. -->

- [x] My change follows the [Contributing Guidelines](./CONTRIBUTING.md)
- [x] I have added only one new link to the list.
- [x] I have checked that the link that I added does NOT exist in the project already.
- [x] I have sorted the link alphabetically under the related section.
