### PR TITLE
Update Google Code Jam link to Google Coding Competitions Archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -722,7 +722,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [Codility](https://codility.com) : Verify and improve coding skills
 - [Codingame](https://www.codingame.com/start) : Learn coding through games and challenges!
 - [Facebook Hacker Cup](https://www.facebook.com/hackercup/) : Facebook's Programming Contest, past problems solutions and FAQ
-- [Google Code Jam Practice and](https://code.google.com/codejam/past-contests) : past contest problems for practice
+- [Google Coding Competitions Archive](https://zibada.guru/gcj/) : past contest problems for practice
 - [HackerEarth - Programming challenges and Developer jobs](https://www.hackerearth.com)
 - [HackerRank](https://www.hackerrank.com) : Practice coding. Compete. Find jobs.
 - [LightOJ](https://lightoj.com) : Practicing at lightoj is so good for beginners as it is categorized and have also chat room and forum which helps to communicate with others about any problem.


### PR DESCRIPTION
#1848 
Issue has been solved.
Changed the Google Code Jam link with an Archive which holds practice questions of Google Code Jam,Kickstart and HashCode.
