### PR TITLE
removed paysa.com and descriptions from the jobs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -950,7 +950,6 @@ When learning CS, there are some useful sites you must know to get always inform
 - [JobsCollider](https://jobscollider.com/remote-jobs) : Tens of thousands of remote jobs from over 10,000 companies and startups worldwide.
 - [Mentat](https://thementat.com) : Get your dream job 10x faster. Never apply for a job ever again, talk directly to decision-makers and hiring managers.
 - [The Muse](https://www.themuse.com) : Find everything you need to succeed from dream jobs to career advice. You can do a lot here on The Muse like exploring companies, browsing jobs, career advice,  discover careers,  career coaching. Try it.
-- [Paysa](https://www.paysa.com) : Paysa helps you in finding new and interesting jobs according to your wish.
 - [SimplyHired](https://www.simplyhired.com) : Simply Hired is a free job search engine (and mobile app) that takes the hassle out of getting hired and provides you with all the information you need to make a sound career move.
 - [SwissDev Jobs](https://swissdevjobs.ch) : Tech job board for Software Engineers that want to work in Switzerland.
 - [Undercover Recruiter](https://theundercoverrecruiter.com) : Become Recruiter,


### PR DESCRIPTION
## Summary of your changes

### Description

I have removed the website named paysa.com from the jobs section as the link does not work , it comes with an error message of DNS server not found

### Checklist

<!--- Please mark all options that apply to your case. -->

- [x] My change follows the [Contributing Guidelines](./CONTRIBUTING.md)
- [x] I have added only one new link to the list.
- [x] I have checked that the link that I added does NOT exist in the project already.
- [x] I have sorted the link alphabetically under the related section.
