### PR TITLE
adding replit url to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [Webhook.site](https://webhook.site/): Useful tool for test and debug webhooks.
 - [kandi](https://kandi.openweaver.com/): Jumpstart Application Development by finding the right Open Source resource
 - [Svix Play](https://play.svix.com/): Webhook tester & debugger. Test webhooks directly from your test suite.
+- [Replit](https://replit.com/): Replit is an AI-powered software development & deployment platform for building, sharing, and shipping software fast.
 
 
 <div align="right">


### PR DESCRIPTION
## Summary of your changes

### Description

Added replit url to the README.md, its a great site for remote teamworking on thinkering projects or tiny projects.

### Checklist

- Added to Readme on line 270 REPLIT entry

<!--- Please mark all options that apply to your case. -->

- [x] My change follows the [Contributing Guidelines](./CONTRIBUTING.md)
- [x] I have added only one new link to the list.
- [x] I have checked that the link that I added does NOT exist in the project already.
- [x] I have sorted the link alphabetically under the related section.
