### PR TITLE
Add Onecompiler.com to Online Compiler and Sharing Code snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -806,6 +806,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [JSFiddle](https://jsfiddle.net) : Test your JavaScript, CSS, HTML or CoffeeScript with online code editor
 - [JSBin](https://jsbin.com/) : Front end playground, Output is not framed, so it allows you to share those snippets that will break inside an iframe.
 - [Judge0 IDE](https://ide.judge0.com) : Online compiler with 40+ interpreters and compilers.
+- [Onecompiler.com](https://onecompiler.com) : A free online compiler that helps over 12.8 million users worldwide write, run, and share code online.  
 - [Pastebin.com](https://pastebin.com) : Pastebin can store texts like code, notes, and snippets online for a set time which can be shared instantly.
 - [PlayCode](https://playcode.io/) : Online Javascript playground with a built-in console and support for npm packages.
 - [RunJS](https://runjs.app/play) : Online JavaScript playground with instant live feedback


### PR DESCRIPTION
- Added Onecompiler.com to Online Compiler and Sharing Code snippets
- OneCompiler is a free online compiler supporting 70+ programming languages and databases.
- Used by over 12.8 million users worldwide.
- Helps users write, run, and share code online.

- [x] My change follows the [Contributing Guidelines](./CONTRIBUTING.md)
- [x] I have added only one new link to the list.
- [x] I have checked that the link that I added does NOT exist in the project already.
- [x] I have sorted the link alphabetically under the related section.
