### PR TITLE
Add CORS-Tester to General tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ When learning CS, there are some useful sites you must know to get always inform
 ## 🛠️ General Tools
 - [CoderPad](https://coderpad.io) : Quickly Conduct Coding Interviews and Phone Screen Interviews.
 - [CodePen](https://codepen.io) : Front End Developer Playground & Code Editor in the Browser
+- [CORS-Tester](https://cors-error.dev/cors-tester/) : A tool for developers and API testers to check if an API is CORS-enabled for a given domain and identify gaps
 - [Crontab Guru](https://crontab.guru/) : Quick and simple editor for cron schedule expressions
 - [Devicons](http://vorillaz.github.io/devicons/#/main) : Cheatsheet for devs icons
 - [Diagrams.net](https://app.diagrams.net/) : Drawing tools to make design and uml easily. Old draw.io


### PR DESCRIPTION
## Summary of your changes

Add CORS-Tester to General tools.

### Description

Add CORS-Tester to General tools. CORS-Tester is a tool for developers and API testers to check if an API is CORS-enabled for a given domain and identify gaps.


### Checklist

<!--- Please mark all options that apply to your case. -->

- [ * ] My change follows the [Contributing Guidelines](./CONTRIBUTING.md)
- [ * ] I have added only one new link to the list.
- [ * ] I have checked that the link that I added does NOT exist in the project already.
- [ * ] I have sorted the link alphabetically under the related section.
