### PR TITLE
Fix README anchor links with emoji characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,40 +15,40 @@ When learning CS, there are some useful sites you must know to get always inform
 
 ## 📖 Index
 <ul>
-<li><a href="#when-you-get-stuck">When you get stuck</a></li>
-<li><a href="#news">News</a></li>
-<li><a href="#magazines">Magazines</a></li>
-<li><a href="#coding-practice-for-beginners">Coding practice for beginners</a></li>
-<li><a href="#cryptocurrency">Cryptocurrency</a></li>
-<li><a href="#for-those-who-want-to-start-a-small-project-but-cant-find-the-ideas">For those who want to start a small project but can't find the ideas</a></li>
+<li><a href="#-when-you-get-stuck">When you get stuck</a></li>
+<li><a href="#-news">News</a></li>
+<li><a href="#-magazines">Magazines</a></li>
+<li><a href="#-coding-practice-for-beginners">Coding practice for beginners</a></li>
+<li><a href="#-cryptocurrency">Cryptocurrency</a></li>
+<li><a href="#-for-those-who-want-to-start-a-small-project-but-cant-find-the-ideas">For those who want to start a small project but can't find the ideas</a></li>
 <li><a href="#general-coding-advice">General Coding advice</a></li>
-<li><a href="#coding-style">Coding Style</a></li>
+<li><a href="#-coding-style">Coding Style</a></li>
 <li><a href="#general-tools">General Tools</a></li>
-<li><a href="#interview-preparation">Interview Preparation</a></li>
-<li><a href="#documentaries">Documentaries</a></li>
-<li><a href="#moocs-for-learning-something-new">MOOCs for learning something new</a></li>
-<li><a href="#sites-related-to-your-preferred-programming-language-for-me-c">Sites related to your preferred programming language (For me C++)</a></li>
-<li><a href="#learn-ai">Artificial Intelligence And Machine Learning</a></li>
-<li><a href="#seminar-research-writing-talks-etc">Seminar , research writing , talks etc</a></li>
-<li><a href="#everything-in-one-place">Everything in one place</a></li>
-<li><a href="#youtube-channels">YouTube Channels</a></li>
+<li><a href="#-interview-preparation">Interview Preparation</a></li>
+<li><a href="#-documentaries">Documentaries</a></li>
+<li><a href="#-moocs-for-learning-something-new">MOOCs for learning something new</a></li>
+<li><a href="#-sites-related-to-your-preferred-programming-language-for-me-c">Sites related to your preferred programming language (For me C++)</a></li>
+<li><a href="#-learn-ai">Artificial Intelligence And Machine Learning</a></li>
+<li><a href="#-seminar-research-writing-talks-etc">Seminar , research writing , talks etc</a></li>
+<li><a href="#-everything-in-one-place">Everything in one place</a></li>
+<li><a href="#-youtube-channels">YouTube Channels</a></li>
 <li><a href="#good-articles">Good Articles</a></li>
-<li><a href="#bash-and-shell-scripting">Bash and Shell scripting</a></li>
-<li><a href="#podcasts">Podcasts</a></li>
-<li><a href="#building-a-simple-compilerinterpreter">Building a Simple Compiler/Interpreter</a></li>
-<li><a href="#watch-others-code">Watch others code</a></li>
-<li><a href="#tutorials">Tutorials</a></li>
-<li><a href="#what-should-a-programmer-know">What should a programmer know</a></li>
+<li><a href="#-bash-and-shell-scripting">Bash and Shell scripting</a></li>
+<li><a href="#-podcasts">Podcasts</a></li>
+<li><a href="#-building-a-simple-compilerinterpreter">Building a Simple Compiler/Interpreter</a></li>
+<li><a href="#-watch-others-code">Watch others code</a></li>
+<li><a href="#-tutorials">Tutorials</a></li>
+<li><a href="#-what-should-a-programmer-know">What should a programmer know</a></li>
 <li><a href="#competitive-programming">Competitive programming</a></li>
-<li><a href="#computer-books">Computer Books</a></li>
-<li><a href="#video-tutorials">Video Tutorials</a></li>
-<li><a href="#online-compiler-and-sharing-code-snippets">Online Compiler and Sharing Code snippets</a></li>
-<li><a href="#blogs-of-developers">Blogs of Developers</a></li>
+<li><a href="#-computer-books">Computer Books</a></li>
+<li><a href="#-video-tutorials">Video Tutorials</a></li>
+<li><a href="#-online-compiler-and-sharing-code-snippets">Online Compiler and Sharing Code snippets</a></li>
+<li><a href="#-blogs-of-developers">Blogs of Developers</a></li>
 <li><a href="#for-improving-your-english">For improving your English</a></li>
 <li><a href="#when-you-get-bored-from-cs-related-stuff">When you get bored from CS related stuff</a></li>
-<li><a href="#open-source-websites">Open Source Websites</a></li>
-<li><a href="#internships">Internships</a></li>
-<li><a href="#jobs">Jobs</a></li>
+<li><a href="#-open-source-websites">Open Source Websites</a></li>
+<li><a href="#-internships">Internships</a></li>
+<li><a href="#-jobs">Jobs</a></li>
 </ul>
 
 ## ❓ When you get stuck
@@ -62,7 +62,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [Coderanch](https://coderanch.com/) : A friendly place for programming greenhorns. Jump straight into any of our topics and light hearted discussions. Ranging from Java, Databases, Android, Programmer certification, Programming jobs and much more...
 
 <div align="right">
-  <b><a href="#index">↥ Back To Top</a></b>
+  <b><a href="#-index">↥ Back To Top</a></b>
 </div>
 
 ## 📰 News
@@ -98,7 +98,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [Hackaday](https://hackaday.com) : Hacking is an art form that uses something in a way in which it was not originally intended.
 
 <div align="right">
-  <b><a href="#index">↥ Back To Top</a></b>
+  <b><a href="#-index">↥ Back To Top</a></b>
 </div>
 
 ## 📚 Magazines
@@ -107,7 +107,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [LWN](https://lwn.net) : Weekly news coverage of opensource technologies, programming, etc. ( Originally Linux Weekly News).
 
 <div align="right">
-  <b><a href="#index">↥ Back To Top</a></b>
+  <b><a href="#-index">↥ Back To Top</a></b>
 </div>
 
 ## 👶 Coding practice for beginners
@@ -142,7 +142,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [SQLTest.online](https://sqltest.online) : Boost Your SQL Proficiency with Challenging Problems.
 
 <div align="right">
-  <b><a href="#index">↥ Back To Top</a></b>
+  <b><a href="#-index">↥ Back To Top</a></b>
 </div>
 
 ## 💰 CryptoCurrency
@@ -160,7 +160,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [Mempool](https://mempool.space): Bitcoin block explorer, mempool visualizer, transaction tracker, and fee estimator 
 
 <div align="right">
-  <b><a href="#index">↥ Back To Top</a></b>
+  <b><a href="#-index">↥ Back To Top</a></b>
 </div>
 
 ## 💡 For those who want to start a small project but can't find the ideas
@@ -173,9 +173,10 @@ When learning CS, there are some useful sites you must know to get always inform
 - [florinpop17/app-ideas](https://github.com/florinpop17/app-ideas) : A Collection of application ideas which can be used to improve your coding skills.
 
 <div align="right">
-  <b><a href="#index">↥ Back To Top</a></b>
+  <b><a href="#-index">↥ Back To Top</a></b>
 </div>
 
+<a id="general-coding-advice"></a>
 ## 🗣️ General Coding advice
 - [How to Begin With Competitive Programming](https://www.geeksforgeeks.org/how-to-begin-with-competitive-programming/)
 - [10-ways-to-be-a-better-developer](https://stephenhaunts.files.wordpress.com/2014/04/10-ways-to-be-a-better-developer.png) : Ways to become a better dev!
@@ -197,7 +198,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [The Open Web Application Security Project (OWASP)](https://www.owasp.org) : OWASP is an open community dedicated to enabling organizations to conceive, develop, acquire, operate, and maintain applications that can be trusted.
 
 <div align="right">
-  <b><a href="#index">↥ Back To Top</a></b>
+  <b><a href="#-index">↥ Back To Top</a></b>
 </div>
 
 ## 🎨 Coding Style
@@ -226,9 +227,10 @@ When learning CS, there are some useful sites you must know to get always inform
 - [Uber Go Style Guide](https://github.com/uber-go/guide): Uber Go Style Guide
 
 <div align="right">
-  <b><a href="#index">↥ Back To Top</a></b>
+  <b><a href="#-index">↥ Back To Top</a></b>
 </div>
 
+<a id="general-tools"></a>
 ## 🛠️ General Tools
 - [CoderPad](https://coderpad.io) : Quickly Conduct Coding Interviews and Phone Screen Interviews.
 - [CodePen](https://codepen.io) : Front End Developer Playground & Code Editor in the Browser
@@ -275,7 +277,7 @@ When learning CS, there are some useful sites you must know to get always inform
 
 
 <div align="right">
-  <b><a href="#index">↥ Back To Top</a></b>
+  <b><a href="#-index">↥ Back To Top</a></b>
 </div>
 
 ## 🐚 Bash and Shell scripting  
@@ -291,7 +293,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [25 Common Linux Bash Script Examples To Get You Started](https://www.hostinger.in/tutorials/bash-script-example) 
 
 <div align="right">
-  <b><a href="#index">↥ Back To Top</a></b>
+  <b><a href="#-index">↥ Back To Top</a></b>
 </div>
 
 ## 🎤 Interview Preparation
@@ -361,7 +363,7 @@ When learning CS, there are some useful sites you must know to get always inform
 
 
 <div align="right">
-  <b><a href="#index">↥ Back To Top</a></b>
+  <b><a href="#-index">↥ Back To Top</a></b>
 </div>
 
 ## 🎬 Documentaries
@@ -382,7 +384,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [The Internet's Own Boy](https://www.youtube.com/watch?v=9vz06QO3UkQ) : The Story of Aaron Swartz
 
 <div align="right">
-  <b><a href="#index">↥ Back To Top</a></b>
+  <b><a href="#-index">↥ Back To Top</a></b>
 </div>
 
 ## 🎓 MOOCs for learning something new
@@ -401,7 +403,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [Pluralsight](https://www.pluralsight.com) : An online learning and workforce development platform that helps businesses and individuals adjust to changing technology.
 
 <div align="right">
-  <b><a href="#index">↥ Back To Top</a></b>
+  <b><a href="#-index">↥ Back To Top</a></b>
 </div>
 
 ## 🧑‍💻 Sites related to your preferred programming language (For me C++)
@@ -442,7 +444,7 @@ When learning CS, there are some useful sites you must know to get always inform
 
 
 <div align="right">
-  <b><a href="#index">↥ Back To Top</a></b>
+  <b><a href="#-index">↥ Back To Top</a></b>
 </div>
 
 ## 🤖 Learn AI
@@ -466,7 +468,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [MLU-EXPLAIN](https://mlu-explain.github.io/) : Machine Learning University (MLU) is an education initiative from Amazon designed for visual explanations of core machine learning concepts.
 
 <div align="right">
-  <b><a href="#index">↥ Back To Top</a></b>
+  <b><a href="#-index">↥ Back To Top</a></b>
 </div>
 
 ## 📢 Seminar, research writing, talks, etc
@@ -478,7 +480,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [Lshort](https://tobi.oetiker.ch/lshort/lshort.pdf) : The Not So Short Introduction to LATEX2ε
 
 <div align="right">
-  <b><a href="#index">↥ Back To Top</a></b>
+  <b><a href="#-index">↥ Back To Top</a></b>
 </div>
 
 ## 📦 Everything in one place
@@ -505,7 +507,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [Library or micro code solutions](https://onelinerhub.com/) : Community library of micro code pieces for popular issues.
 
 <div align="right">
-  <b><a href="#index">↥ Back To Top</a></b>
+  <b><a href="#-index">↥ Back To Top</a></b>
 </div>
 
 ## 📺 YouTube Channels
@@ -558,9 +560,10 @@ When learning CS, there are some useful sites you must know to get always inform
 - [Take You Forward](https://www.youtube.com/c/takeUforward): Tutorials on Data structures and Algorithms in Java and C++.
 
 <div align="right">
-  <b><a href="#index">↥ Back To Top</a></b>
+  <b><a href="#-index">↥ Back To Top</a></b>
 </div>
 
+<a id="good-articles"></a>
 ## ✍️ Good Articles
 - [14 Things I Wish I’d Known When Starting with MongoDB](https://www.infoq.com/articles/Starting-With-MongoDB/)
 - [40 Keys Computer Science Concepts Explained In Layman’s Terms](http://carlcheo.com/compsci)
@@ -590,7 +593,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [How I got TensorFlow Developer Certified](https://www.mrdbourke.com/how-i-got-tensorflow-developer-certified/) : Step By Step guide to pass Tensorflow Developer Certification
 
 <div align="right">
-  <b><a href="#index">↥ Back To Top</a></b>
+  <b><a href="#-index">↥ Back To Top</a></b>
 </div>
 
 ## 🎧 Podcasts
@@ -621,7 +624,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [Python bytes](https://pythonbytes.fm) Podcast to learn about the latest happenings and trends in Python
 
 <div align="right">
-  <b><a href="#index">↥ Back To Top</a></b>
+  <b><a href="#-index">↥ Back To Top</a></b>
 </div>
 
 ## 🔄 Building a Simple Compiler/Interpreter
@@ -638,7 +641,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [Writing a C Compiler](https://norasandler.com/2017/11/29/Write-a-Compiler.html) : The first post in a series by Nora Sandler on writing your own C compiler
 
 <div align="right">
-  <b><a href="#index">↥ Back To Top</a></b>
+  <b><a href="#-index">↥ Back To Top</a></b>
 </div>
 
 ## 🧑‍🏫 Tutorials
@@ -699,7 +702,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [Javascript.info](https://javascript.info/) : The Modern JavaScript Tutorial
 
 <div align="right">
-  <b><a href="#index">↥ Back To Top</a></b>
+  <b><a href="#-index">↥ Back To Top</a></b>
 </div>
 
 ## 👀 Watch others code
@@ -707,7 +710,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [Twitch.tv](https://www.twitch.tv/directory/game/Science%20%26%20Technology) : The programming community of twitch.
 
 <div align="right">
-  <b><a href="#index">↥ Back To Top</a></b>
+  <b><a href="#-index">↥ Back To Top</a></b>
 </div>
 
 ## 🧠 What should a programmer know
@@ -717,9 +720,10 @@ When learning CS, there are some useful sites you must know to get always inform
 - [Programmer Competency Matrix](https://www.sijinjoseph.com/programmer-competency-matrix/) : article for knowing what our level as a programmer is.
 
 <div align="right">
-  <b><a href="#index">↥ Back To Top</a></b>
+  <b><a href="#-index">↥ Back To Top</a></b>
 </div>
 
+<a id="competitive-programming"></a>
 ## ⚔️  Competitive programming
 - [Topic Wise Problem For Competitive Programmer](https://a2oj.com/categories) : Topic wise Practise Problem
 - [Advent of Code](https://adventofcode.com) : An Advent calendar of small programming puzzles
@@ -748,7 +752,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [A2OJ Ladders](https://a2oj.com/Ladders.html) : Practice codeforces problems based on your proficiency and difficulty
 
 <div align="right">
-  <b><a href="#index">↥ Back To Top</a></b>
+  <b><a href="#-index">↥ Back To Top</a></b>
 </div>
 
 ## 📖 Computer Books
@@ -764,7 +768,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [programmingbooks.dev](https://www.programmingbooks.dev) : An Ordered and Curated Reading List for Software Craftsmanship Growth.
 
 <div align="right">
-  <b><a href="#index">↥ Back To Top</a></b>
+  <b><a href="#-index">↥ Back To Top</a></b>
 </div>
 
 ## 🔴 Video Tutorials
@@ -791,7 +795,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [Mastering Next.js](https://masteringnextjs.com/) : A free serie of videos to learn Next.js
 
 <div align="right">
-  <b><a href="#index">↥ Back To Top</a></b>
+  <b><a href="#-index">↥ Back To Top</a></b>
 </div>
 
 ## 💻 Online Compiler and Sharing Code snippets
@@ -816,7 +820,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [PHPize.online](https://phpize.online/): Online PHP compiler with SQL support.
 
 <div align="right">
-  <b><a href="#index">↥ Back To Top</a></b>
+  <b><a href="#-index">↥ Back To Top</a></b>
 </div>
 
 ## 📝 Blogs of Developers
@@ -861,9 +865,10 @@ When learning CS, there are some useful sites you must know to get always inform
 - [The Net Ninja](https://www.thenetninja.co.uk/): Web development tutorials
 
 <div align="right">
-  <b><a href="#index">↥ Back To Top</a></b>
+  <b><a href="#-index">↥ Back To Top</a></b>
 </div>
 
+<a id="for-improving-your-english"></a>
 ## 🗣️ For improving your English
 - [Englishclub.com/learn-english](https://www.englishclub.com/learn-english.htm)
 - [Guide to Grammar and Writing](http://grammar.ccc.commnet.edu/grammar/) : for those who want to improve their English language skills
@@ -873,9 +878,10 @@ When learning CS, there are some useful sites you must know to get always inform
 - [AntiMoon Immersion Approach](http://www.antimoon.com/how/howtolearn.htm): Immersion-based learning of English, can be used by people on different levels.
 
 <div align="right">
-  <b><a href="#index">↥ Back To Top</a></b>
+  <b><a href="#-index">↥ Back To Top</a></b>
 </div>
 
+<a id="when-you-get-bored-from-cs-related-stuff"></a>
 ## 🧘‍♂️ When you get bored from CS related stuff
 - [Barcroft TV](https://www.youtube.com/user/barcroftmedia/featured) : Daily short documentaries about the incredible variety of people that make up the world
 - [Big Think](https://www.youtube.com/user/bigthink/videos) : Expert driven, actionable, educational content, featuring experts ranging from Bill Clinton to Bill Nye
@@ -897,7 +903,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [lonelyspeck](https://www.lonelyspeck.com/the-milky-way-in-los-angeles-light-pollution/) : Expose to the Right for Astrophotography in Light Pollution – Palos Verdes, Los Angeles, California
 
 <div align="right">
-  <b><a href="#index">↥ Back To Top</a></b>
+  <b><a href="#-index">↥ Back To Top</a></b>
 </div>
 
 ## 🔓 Open Source Websites
@@ -925,7 +931,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [MLH Fellowship prgramme](https://fellowship.mlh.io/):A fully remote, 12-week internship alternative where participants earn a stipend and learn to collaborate on real open source projects with peers and engineers from top companies.
 
 <div align="right">
-  <b><a href="#index">↥ Back To Top</a></b>
+  <b><a href="#-index">↥ Back To Top</a></b>
 </div>
 
 ## 🌱 Internships
@@ -935,7 +941,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [PerfectIntern](https://www.perfectintern.com): Get help finding a paid internship, resume prep, interview prep, and more!
 
 <div align="right">
-  <b><a href="#index">↥ Back To Top</a></b>
+  <b><a href="#-index">↥ Back To Top</a></b>
 </div>
 
 ## 💼 Jobs
@@ -970,7 +976,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [OkJob](https://okjob.io/) : 4 day week job board.
 
 <div align="right">
-  <b><a href="#index">↥ Back To Top</a></b>
+  <b><a href="#-index">↥ Back To Top</a></b>
 </div>
 
 ### 🌟 Special Thanks


### PR DESCRIPTION
## Summary of your changes

This commit fixes the navigation links in the README index section by properly handling emoji characters in anchor links. GitHub's Markdown processor treats emoji characters differently when generating heading IDs, causing links with emojis to break.

### Description

The fix implements two approaches:
1. Using explicit anchor tags for sections with emoji headings
2. Ensuring anchor links properly reference headings with emoji characters

This change improves the README navigation experience and ensures all section links work correctly when clicked.

### Checklist
<!--- Please mark all options that apply to your case. -->
- [ ✓ ] My change follows the [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] I have added only one new link to the list.
- [ ] I have checked that the link that I added does NOT exist in the project already.
- [ ] I have sorted the link alphabetically under the related section.
