### PR TITLE
remove https://www.sijinjoseph.com/programmer-competency-matrix/ for

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,7 +715,6 @@ When learning CS, there are some useful sites you must know to get always inform
 - [Can I use](https://caniuse.com/) : A website that provides up-to-date browser support tables for support of front-end web technologies on desktop and mobile web browsers.
 - [GitHub.com Build software better, together](https://github.com) : Place to showcase your project and collaborate with others. (Must know Git to use it effectively)
 - [GitLab](https://about.gitlab.com) : An alternative to GitHub that offers free unlimited (private) repositories and unlimited collaborators.
-- [Programmer Competency Matrix](https://www.sijinjoseph.com/programmer-competency-matrix/) : article for knowing what our level as a programmer is.
 
 <div align="right">
   <b><a href="#index">↥ Back To Top</a></b>


### PR DESCRIPTION
Remove Broken Link  | Missing SSL cert

## Summary of your changes
I removed the https://www.sijinjoseph.com/programmer-competency-matrix/ link 

### Description
I was reading through the repo and noticed that the https://www.sijinjoseph.com/programmer-competency-matrix/ link was broken due to a missing SSL certificate. This PR removes the broken link.
<img width="935" height="985" alt="image" src="https://github.com/user-attachments/assets/b6300b33-8d81-49c6-ad12-36a62f89099c" />


### Checklist

- [x] My change follows the [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] I have added only one new link to the list.
- [ ] I have checked that the link that I added does NOT exist in the project already.
- [ ] I have sorted the link alphabetically under the related section.

