### PR TITLE
Fixed: Broken image in README #2032

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@
     <br>
 </h1>
 
-[![Build Status](https://api.travis-ci.org/sdmg15/Best-websites-a-programmer-should-visit.svg?branch=master)](https://travis-ci.org/sdmg15/Best-websites-a-programmer-should-visit)
+
+
+![GitHub tag (latest by date)](https://img.shields.io/github/v/tag/AlokPy1484/Best-websites-a-programmer-should-visit)
+
 
 # Best-websites-a-programmer-should-visit
 Some useful websites for programmers.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 
 
-![GitHub tag (latest by date)](https://img.shields.io/github/v/tag/AlokPy1484/Best-websites-a-programmer-should-visit)
+![GitHub tag (latest by date)](https://img.shields.io/github/v/tag/sdmg15/Best-websites-a-programmer-should-visit)
 
 
 # Best-websites-a-programmer-should-visit

--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@
 
 
 
-![GitHub tag (latest by date)](https://img.shields.io/github/v/tag/sdmg15/Best-websites-a-programmer-should-visit)
+<!--![GitHub tag (latest by date)](https://img.shields.io/github/v/tag/sdmg15/Best-websites-a-programmer-should-visit)-->
+
+![GitHub Repo stars](https://img.shields.io/github/stars/sdmg15/Best-websites-a-programmer-should-visit?style=social)
+
 
 
 # Best-websites-a-programmer-should-visit


### PR DESCRIPTION
There is a broken Travis build version badge in README which I replace with working alternative 

### Description

While going though main repo a broken badge caught my attention. Upon further investigation I realise it is badge that displays build status of Travis CI repo. As I am unable to access the travis repo so I thought of an alternative that displays release version of Github repo. This repository currently doesn't have a release made so I have commented release tag in README.md for future use and have added the "stars count" badge as a placeholder. 


Fixes #2032

### Checklist

<!--- Please mark all options that apply to your case. -->

- [x] My change follows the [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] I have added only one new link to the list.
- [ ] I have checked that the link that I added does NOT exist in the project already.
- [ ] I have sorted the link alphabetically under the related section.


<img width="1440" height="900" alt="Screenshot 2025-10-02 at 8 19 23 AM" src="https://github.com/user-attachments/assets/af1680e0-8300-4ec4-b2d5-1d77a47290d9" />


