### PR TITLE
Remove Letsintern from internship resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -931,7 +931,6 @@ When learning CS, there are some useful sites you must know to get always inform
 ## 🌱 Internships
 - [Chegg](http://www.chegg.com) : It is an awesome resource for finding internships, scholarships, tutors, etc.
 - [Internshala](https://internshala.com) : You can search for internships here according to your skill sets for your interested location. It also helps you in getting a good PPO offer from the company.
-- [Letsintern](https://www.letsintern.com) : Get a smart and challenging internship for you from the LetsIntern.
 - [PerfectIntern](https://www.perfectintern.com): Get help finding a paid internship, resume prep, interview prep, and more!
 
 <div align="right">


### PR DESCRIPTION
## Summary of your changes

### Description
Removed Letsintern from the list of internship resources. It's domain has been bought by a crypto/trading firm it seems.
Related to: https://github.com/sdmg15/Best-websites-a-programmer-should-visit/issues/1987
<!--- Please include a summary of the changes and the related issue. -->
<!--- If your changes closes an issue ticket, please refer it as: Fixes #<number> -->

### Checklist

<!--- Please mark all options that apply to your case. -->

- [ ] My change follows the [Contributing Guidelines](./CONTRIBUTING.md)
- [ ] I have added only one new link to the list.
- [ ] I have checked that the link that I added does NOT exist in the project already.
- [ ] I have sorted the link alphabetically under the related section.
