### PR TITLE
Add Frontend Mentor to the list of websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [Programming by Doing](http://programmingbydoing.com) : very good site for those who want to start with absolute basics
 - [CodeAbbey - a place where everyone can master programming](http://www.codeabbey.com) : Best place to begin with problems that start at the easiest and gradually increase difficulty with each problem.
 - [Exercism.io](http://exercism.io) : Download and solve practice problems in over 50 different languages, and share your solution with others.
-- [Frontendmentor.io]((https://www.frontendmentor.io/)) : Offers real-world front-end coding challenges to practice HTML, CSS, and JavaScript by building projects.
+- [Frontendmentor.io](https://www.frontendmentor.io/) : Offers real-world front-end coding challenges to practice HTML, CSS, and JavaScript by building projects.
 - [InterviewBit/Coding Interview Questions](https://www.interviewbit.com) : Gamifies the experience of practicing for your interview and includes lots of sample problems to solve.
 - [karan/Projects-Solutions](https://github.com/karan/Projects-Solutions) : Solutions to most of the problems in the link above
 - [Lod - Cloud](http://lod-cloud.net) : The Linking Open Data cloud diagram

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [Programming by Doing](http://programmingbydoing.com) : very good site for those who want to start with absolute basics
 - [CodeAbbey - a place where everyone can master programming](http://www.codeabbey.com) : Best place to begin with problems that start at the easiest and gradually increase difficulty with each problem.
 - [Exercism.io](http://exercism.io) : Download and solve practice problems in over 50 different languages, and share your solution with others.
+- [Frontendmentor.io]((https://www.frontendmentor.io/)) : Offers real-world front-end coding challenges to practice HTML, CSS, and JavaScript by building projects.
 - [InterviewBit/Coding Interview Questions](https://www.interviewbit.com) : Gamifies the experience of practicing for your interview and includes lots of sample problems to solve.
 - [karan/Projects-Solutions](https://github.com/karan/Projects-Solutions) : Solutions to most of the problems in the link above
 - [Lod - Cloud](http://lod-cloud.net) : The Linking Open Data cloud diagram


### PR DESCRIPTION
## Summary of your changes

Added [Frontend Mentor](https://www.frontendmentor.io) to the list — a website that provides real-world frontend challenges to help developers improve their HTML, CSS, and JavaScript skills through hands-on projects.

---

### Description

Frontend Mentor is an interactive platform offering real client-style UI challenges. Developers can practice responsive layouts, component-based design, and accessibility while comparing solutions with a supportive community. It’s a great resource for strengthening practical frontend development skills beyond tutorials.

---

### Checklist

- [x] My change follows the [Contributing Guidelines](./CONTRIBUTING.md)
- [x] I have added only one new link to the list.
- [x] I have checked that the link that I added does **NOT** exist in the project already.
- [x] I have sorted the link alphabetically under the related section.
