### PR TITLE
Add USACO.guide to competitive programming list

### DIFF
--- a/README.md
+++ b/README.md
@@ -746,6 +746,7 @@ When learning CS, there are some useful sites you must know to get always inform
 - [WakaTime](https://wakatime.com) : leaderboards of coding metrics collected via editor plugins
 - [PrepBytes](https://mycode.prepbytes.com/competitive-coding/practice) : Topic and level wise proper arrange problems 
 - [A2OJ Ladders](https://a2oj.com/Ladders.html) : Practice codeforces problems based on your proficiency and difficulty
+- [USACO.guide](https://usaco.guide) : A structured, level-based training platform for competitive programming and Olympiads, centered around the USACO curriculum.
 
 <div align="right">
   <b><a href="#index">↥ Back To Top</a></b>


### PR DESCRIPTION
## Summary of your changes

### Description

Adds USACO.guide to the "Competitive programming" section.

This is a structured, level-based training platform for competitive programming and Olympiads. This pull request follows all of the repository's contribution guidelines.

### Checklist

<!--- Please mark all options that apply to your case. -->

- [ x] My change follows the [Contributing Guidelines](./CONTRIBUTING.md)
- [ x] I have added only one new link to the list.
- [ x] I have checked that the link that I added does NOT exist in the project already.
- [ x] I have sorted the link alphabetically under the related section.
